### PR TITLE
Feature/logs

### DIFF
--- a/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStep.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStep.swift
@@ -1,0 +1,44 @@
+//
+//  ActivityLogAnalyzerControlFlowStep.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogAnalyzerStep
+//  * Kind: object
+//  * Properties:
+//    + parentIndex: Int
+//
+//      - ActivityLogAnalyzerControlFlowStep
+//        * Supertype: ActivityLogAnalyzerStep
+//        * Kind: object
+//        * Properties:
+//          + title: String
+//          + startLocation: DocumentLocation?
+//          + endLocation: DocumentLocation?
+//          + edges: [ActivityLogAnalyzerControlFlowStepEdge]
+
+public struct ActivityLogAnalyzerControlFlowStep: XCResultObject {
+    public let parentIndex: Int
+    public let title: String
+    public let startLocation: DocumentLocation?
+    public let endLocation: DocumentLocation?
+    public let edges: [ActivityLogAnalyzerControlFlowStepEdge]
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            parentIndex = try xcRequired(element: "parentIndex", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startLocation = xcOptional(element: "startLocation", from: json)
+            endLocation = xcOptional(element: "endLocation", from: json)
+            edges = xcArray(element: "edges", from: json)
+                .ofType(ActivityLogAnalyzerControlFlowStepEdge.self)
+        } catch {
+            debug("Error parsing ActivityLogAnalyzerControlFlowStep: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStepEdge.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStepEdge.swift
@@ -1,0 +1,24 @@
+//
+//  ActivityLogAnalyzerControlFlowStepEdge.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogAnalyzerControlFlowStepEdge
+//  * Kind: object
+//  * Properties:
+//    + startLocation: DocumentLocation?
+//    + endLocation: DocumentLocation?
+
+public struct ActivityLogAnalyzerControlFlowStepEdge: XCResultObject {
+    public let startLocation: DocumentLocation?
+    public let endLocation: DocumentLocation?
+
+    public init?(_ json: [String : AnyObject]) {
+        startLocation = xcOptional(element: "startLocation", from: json)
+        endLocation = xcOptional(element: "endLocation", from: json)
+    }
+}

--- a/Sources/XCResultKit/ActivityLogAnalyzerEventStep.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerEventStep.swift
@@ -1,0 +1,43 @@
+//
+//  ActivityLogAnalyzerEventStep.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogAnalyzerStep
+//  * Kind: object
+//  * Properties:
+//    + parentIndex: Int
+//
+//        - ActivityLogAnalyzerEventStep
+//          * Supertype: ActivityLogAnalyzerStep
+//          * Kind: object
+//          * Properties:
+//            + title: String
+//            + location: DocumentLocation?
+//            + description: String
+//            + callDepth: Int
+
+public struct ActivityLogAnalyzerEventStep: XCResultObject {
+    public let parentIndex: Int
+    public let title: String
+    public let location: DocumentLocation?
+    public let description: String
+    public let callDepth: Int
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            parentIndex = try xcRequired(element: "parentIndex", from: json)
+            title = try xcRequired(element: "title", from: json)
+            location = xcOptional(element: "location", from: json)
+            description = try xcRequired(element: "description", from: json)
+            callDepth = try xcRequired(element: "callDepth", from: json)
+        } catch {
+            debug("Error parsing ActivityLogAnalyzerEventStep: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogAnalyzerResultMessage.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerResultMessage.swift
@@ -1,0 +1,52 @@
+//
+//  ActivityLogAnalyzerResultMessage.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogAnalyzerResultMessage
+//* Supertype: ActivityLogMessage
+//* Kind: object
+//* Properties:
+//  + steps: [ActivityLogAnalyzerStep]
+//  + resultType: String?
+//  + keyEventIndex: Int
+
+public struct ActivityLogAnalyzerResultMessage: XCResultObject {
+    public let type: String
+    public let title: String
+    public let shortTitle: String?
+    public let category: String?
+    public let location: DocumentLocation
+    public let annotations: [ActivityLogMessageAnnotation]
+
+    public let controlFlowSteps: [ActivityLogAnalyzerControlFlowStep]
+    public let eventSteps: [ActivityLogAnalyzerEventStep]
+    public let resultType: String?
+    public let keyEventIndex: Int
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            type = try xcRequired(element: "type", from: json)
+            title = try xcRequired(element: "title", from: json)
+            shortTitle = xcOptional(element: "shortTitle", from: json)
+            category = xcOptional(element: "category", from: json)
+            location = try xcRequired(element: "location", from: json)
+            annotations = xcArray(element: "annotation", from: json)
+                .ofType(ActivityLogMessageAnnotation.self)
+
+            controlFlowSteps = xcArray(element: "steps", from: json)
+                .ofType(ActivityLogAnalyzerControlFlowStep.self)
+            eventSteps = xcArray(element: "steps", from: json)
+            .ofType(ActivityLogAnalyzerEventStep.self)
+            resultType = xcOptional(element: "resultType", from: json)
+            keyEventIndex = try xcRequired(element: "keyEventIndex", from: json)
+        } catch {
+            debug("Error parsing ActivityLogAnalyzerResultMessage: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogAnalyzerWarningMessage.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerWarningMessage.swift
@@ -1,0 +1,36 @@
+//
+//  ActivityLogAnalyzerWarningMessage.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogAnalyzerWarningMessage
+// * Supertype: ActivityLogMessage
+// * Kind: object
+
+public struct ActivityLogAnalyzerWarningMessage: XCResultObject {
+    public let type: String
+    public let title: String
+    public let shortTitle: String?
+    public let category: String?
+    public let location: DocumentLocation
+    public let annotations: [ActivityLogMessageAnnotation]
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            type = try xcRequired(element: "type", from: json)
+            title = try xcRequired(element: "title", from: json)
+            shortTitle = xcOptional(element: "shortTitle", from: json)
+            category = xcOptional(element: "category", from: json)
+            location = try xcRequired(element: "location", from: json)
+            annotations = xcArray(element: "annotation", from: json)
+                .ofType(ActivityLogMessageAnnotation.self)
+        } catch {
+            debug("Error parsing ActivityLogAnalyzerWarningMessage: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
+++ b/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
@@ -30,7 +30,7 @@ public struct ActivityLogCommandInvocationSection: XCResultObject {
     public let warningMessage: [ActivityLogAnalyzerWarningMessage]
 
     public let commandDetails: String
-    public let emittedOutput: String
+    public let emittedOutput: String?
     public let exitCode: Int?
 
     public init?(_ json: [String : AnyObject]) {
@@ -56,7 +56,7 @@ public struct ActivityLogCommandInvocationSection: XCResultObject {
                 .ofType(ActivityLogAnalyzerWarningMessage.self)
 
             commandDetails = try xcRequired(element: "commandDetails", from: json)
-            emittedOutput = try xcRequired(element: "emittedOutput", from: json)
+            emittedOutput = xcOptional(element: "emittedOutput", from: json)
             exitCode = xcOptional(element: "exitCode", from: json)
         } catch {
             debug("Error parsing ActivityLogCommandInvocationSection: \(error.localizedDescription)")

--- a/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
+++ b/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
@@ -1,0 +1,66 @@
+//
+//  ActivityLogCommandInvocationSection.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogCommandInvocationSection
+//* Supertype: ActivityLogSection
+//* Kind: object
+//* Properties:
+//  + commandDetails: String
+//  + emittedOutput: String
+//  + exitCode: Int?
+
+public struct ActivityLogCommandInvocationSection: XCResultObject {
+    public let domainType: String
+    public let title: String
+    public let startTime: Date?
+    public let duration: Double
+    public let result: String?
+    public let subsections: [ActivityLogMajorSection]
+    public let unitTestSubsections: [ActivityLogUnitTestSection]
+    public let commandInvocationSubsections: [ActivityLogCommandInvocationSection]
+    public let targetBuildSubsections: [ActivityLogTargetBuildSection]
+    public let messages: [ActivityLogMessage]
+    public let resultMessages: [ActivityLogAnalyzerResultMessage]
+    public let warningMessage: [ActivityLogAnalyzerWarningMessage]
+
+    public let commandDetails: String
+    public let emittedOutput: String
+    public let exitCode: Int?
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            domainType = try xcRequired(element: "domainType", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startTime = xcOptional(element: "startTime", from: json)
+            duration = try xcRequired(element: "duration", from: json)
+            result = xcOptional(element: "result", from: json)
+            subsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogMajorSection.self)
+            unitTestSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogUnitTestSection.self)
+            commandInvocationSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogCommandInvocationSection.self)
+            targetBuildSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogTargetBuildSection.self)
+            messages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogMessage.self)
+            resultMessages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerResultMessage.self)
+            warningMessage = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerWarningMessage.self)
+
+            commandDetails = try xcRequired(element: "commandDetails", from: json)
+            emittedOutput = try xcRequired(element: "emittedOutput", from: json)
+            exitCode = xcOptional(element: "exitCode", from: json)
+        } catch {
+            debug("Error parsing ActivityLogCommandInvocationSection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogMajorSection.swift
+++ b/Sources/XCResultKit/ActivityLogMajorSection.swift
@@ -1,0 +1,60 @@
+//
+//  ActivityLogMajorSection.swift
+//  XCResultKitTests
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogMajorSection
+//* Supertype: ActivityLogSection
+//* Kind: object
+//* Properties:
+//  + subtitle: String
+
+public struct ActivityLogMajorSection: XCResultObject {
+    public let domainType: String
+    public let title: String
+    public let startTime: Date?
+    public let duration: Double
+    public let result: String?
+    public let subsections: [ActivityLogMajorSection]
+    public let unitTestSubsections: [ActivityLogUnitTestSection]
+    public let commandInvocationSubsections: [ActivityLogCommandInvocationSection]
+    public let targetBuildSubsections: [ActivityLogTargetBuildSection]
+    public let messages: [ActivityLogMessage]
+    public let resultMessages: [ActivityLogAnalyzerResultMessage]
+    public let warningMessage: [ActivityLogAnalyzerWarningMessage]
+
+    public let subtitle: String
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            domainType = try xcRequired(element: "domainType", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startTime = xcOptional(element: "startTime", from: json)
+            duration = try xcRequired(element: "duration", from: json)
+            result = xcOptional(element: "result", from: json)
+            subsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogMajorSection.self)
+            unitTestSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogUnitTestSection.self)
+            commandInvocationSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogCommandInvocationSection.self)
+            targetBuildSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogTargetBuildSection.self)
+            messages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogMessage.self)
+            resultMessages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerResultMessage.self)
+            warningMessage = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerWarningMessage.self)
+
+            subtitle = try xcRequired(element: "subtitle", from: json)
+        } catch {
+            debug("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogMessage.swift
+++ b/Sources/XCResultKit/ActivityLogMessage.swift
@@ -1,0 +1,42 @@
+//
+//  ActivityLogMessage.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 03/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogMessage
+//  * Kind: object
+//  * Properties:
+//    + type: String
+//    + title: String
+//    + shortTitle: String?
+//    + category: String?
+//    + location: DocumentLocation?
+//    + annotations: [ActivityLogMessageAnnotation]
+
+public struct ActivityLogMessage: XCResultObject {
+    public let type: String
+    public let title: String
+    public let shortTitle: String?
+    public let category: String?
+    public let location: DocumentLocation
+    public let annotations: [ActivityLogMessageAnnotation]
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            type = try xcRequired(element: "type", from: json)
+            title = try xcRequired(element: "title", from: json)
+            shortTitle = xcOptional(element: "shortTitle", from: json)
+            category = xcOptional(element: "category", from: json)
+            location = try xcRequired(element: "location", from: json)
+            annotations = xcArray(element: "annotation", from: json)
+                .ofType(ActivityLogMessageAnnotation.self)
+        } catch {
+            debug("Error parsing ActivityLogMessage: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogMessageAnnotation.swift
+++ b/Sources/XCResultKit/ActivityLogMessageAnnotation.swift
@@ -1,0 +1,29 @@
+//
+//  ActivityLogMessageAnnotation.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 03/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogMessageAnnotation
+//  * Kind: object
+//  * Properties:
+//    + title: String
+//    + location: DocumentLocation?
+
+public struct ActivityLogMessageAnnotation: XCResultObject {
+    public let title: String
+    public let location: DocumentLocation?
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            title = try xcRequired(element: "title", from: json)
+            location = xcOptional(element: "location", from: json)
+        } catch {
+            debug("Error parsing ActivityLogMessageAnnotation: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogSection.swift
+++ b/Sources/XCResultKit/ActivityLogSection.swift
@@ -1,0 +1,61 @@
+//
+//  ActivityLogSection.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 03/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogSection
+//  * Kind: object
+//  * Properties:
+//    + domainType: String
+//    + title: String
+//    + startTime: Date?
+//    + duration: Double
+//    + result: String?
+//    + subsections: [ActivityLogSection]
+//    + messages: [ActivityLogMessage]
+
+public struct ActivityLogSection: XCResultObject {
+    public let domainType: String
+    public let title: String
+    public let startTime: Date?
+    public let duration: Double
+    public let result: String?
+    public let subsections: [ActivityLogMajorSection]
+    public let unitTestSubsections: [ActivityLogUnitTestSection]
+    public let commandInvocationSubsections: [ActivityLogCommandInvocationSection]
+    public let targetBuildSubsections: [ActivityLogTargetBuildSection]
+    public let messages: [ActivityLogMessage]
+    public let resultMessages: [ActivityLogAnalyzerResultMessage]
+    public let warningMessage: [ActivityLogAnalyzerWarningMessage]
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            domainType = try xcRequired(element: "domainType", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startTime = xcOptional(element: "startTime", from: json)
+            duration = try xcRequired(element: "duration", from: json)
+            result = xcOptional(element: "result", from: json)
+            subsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogMajorSection.self)
+            unitTestSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogUnitTestSection.self)
+            commandInvocationSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogCommandInvocationSection.self)
+            targetBuildSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogTargetBuildSection.self)
+            messages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogMessage.self)
+            resultMessages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerResultMessage.self)
+            warningMessage = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerWarningMessage.self)
+        } catch {
+            debug("Error parsing ActivityLogSection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogTargetBuildSection.swift
+++ b/Sources/XCResultKit/ActivityLogTargetBuildSection.swift
@@ -1,0 +1,62 @@
+//
+//  ActivityLogTargetBuildSection.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogTargetBuildSection
+//  * Supertype: ActivityLogMajorSection
+//  * Kind: object
+//  * Properties:
+//    + productType: String?
+
+public struct ActivityLogTargetBuildSection: XCResultObject {
+    public let domainType: String
+    public let title: String
+    public let startTime: Date?
+    public let duration: Double
+    public let result: String?
+    public let subsections: [ActivityLogMajorSection]
+    public let unitTestSubsections: [ActivityLogUnitTestSection]
+    public let commandInvocationSubsections: [ActivityLogCommandInvocationSection]
+    public let targetBuildSubsections: [ActivityLogTargetBuildSection]
+    public let messages: [ActivityLogMessage]
+    public let resultMessages: [ActivityLogAnalyzerResultMessage]
+    public let warningMessage: [ActivityLogAnalyzerWarningMessage]
+
+    public let subtitle: String
+    public let productType: String?
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            domainType = try xcRequired(element: "domainType", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startTime = xcOptional(element: "startTime", from: json)
+            duration = try xcRequired(element: "duration", from: json)
+            result = xcOptional(element: "result", from: json)
+            subsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogMajorSection.self)
+            unitTestSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogUnitTestSection.self)
+            commandInvocationSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogCommandInvocationSection.self)
+            targetBuildSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogTargetBuildSection.self)
+            messages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogMessage.self)
+            resultMessages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerResultMessage.self)
+            warningMessage = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerWarningMessage.self)
+
+            subtitle = try xcRequired(element: "subtitle", from: json)
+            productType = xcOptional(element: "productType", from: json)
+        } catch {
+            debug("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/ActivityLogUnitTestSection.swift
+++ b/Sources/XCResultKit/ActivityLogUnitTestSection.swift
@@ -1,0 +1,81 @@
+//
+//  ActivityLogUnitTestSection.swift
+//  XCResultKit
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+
+//- ActivityLogUnitTestSection
+//  * Supertype: ActivityLogSection
+//  * Kind: object
+//  * Properties:
+//    + testName: String?
+//    + suiteName: String?
+//    + summary: String?
+//    + emittedOutput: String?
+//    + performanceTestOutput: String?
+//    + testsPassedString: String?
+//    + runnablePath: String?
+//    + runnableUTI: String?
+
+public struct ActivityLogUnitTestSection: XCResultObject {
+    public let domainType: String
+    public let title: String
+    public let startTime: Date?
+    public let duration: Double
+    public let result: String?
+    public let subsections: [ActivityLogMajorSection]
+    public let unitTestSubsections: [ActivityLogUnitTestSection]
+    public let commandInvocationSubsections: [ActivityLogCommandInvocationSection]
+    public let targetBuildSubsections: [ActivityLogTargetBuildSection]
+    public let messages: [ActivityLogMessage]
+    public let resultMessages: [ActivityLogAnalyzerResultMessage]
+    public let warningMessage: [ActivityLogAnalyzerWarningMessage]
+
+    public let testName: String?
+    public let suiteName: String?
+    public let summary: String?
+    public let emittedOutput: String?
+    public let performanceTestOutput: String?
+    public let testsPassedString: String?
+    public let runnablePath: String?
+    public let runnableUTI: String?
+
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            domainType = try xcRequired(element: "domainType", from: json)
+            title = try xcRequired(element: "title", from: json)
+            startTime = xcOptional(element: "startTime", from: json)
+            duration = try xcRequired(element: "duration", from: json)
+            result = xcOptional(element: "result", from: json)
+            subsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogMajorSection.self)
+            unitTestSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogUnitTestSection.self)
+            commandInvocationSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogCommandInvocationSection.self)
+            targetBuildSubsections = xcArray(element: "subsections", from: json)
+                .ofType(ActivityLogTargetBuildSection.self)
+            messages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogMessage.self)
+            resultMessages = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerResultMessage.self)
+            warningMessage = xcArray(element: "messages", from: json)
+                .ofType(ActivityLogAnalyzerWarningMessage.self)
+
+            testName = xcOptional(element: "testName", from: json)
+            suiteName = xcOptional(element: "suiteName", from: json)
+            summary = xcOptional(element: "summary", from: json)
+            emittedOutput = xcOptional(element: "emittedOutput", from: json)
+            performanceTestOutput = xcOptional(element: "performanceTestOutput", from: json)
+            testsPassedString = xcOptional(element: "testsPassedString", from: json)
+            runnablePath = xcOptional(element: "runnablePath", from: json)
+            runnableUTI = xcOptional(element: "runnableUTI", from: json)
+        } catch {
+            debug("Error parsing ActivityLogUnitTestSection: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -64,6 +64,28 @@ public class XCResultFile {
             return nil
         }
     }
+
+    public func getLogs(id: String) -> ActivityLogSection? {
+        guard let getOutput = shell(command: ["-l", "-c", "xcrun xcresulttool get --path \(url.path) --id \(id) --format json"]) else {
+            return nil
+        }
+
+        do {
+            guard let data = getOutput.data(using: .utf8) else {
+                debug("Unable to turn string into data, must not be a utf8 string")
+                return nil
+            }
+            guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
+                debug("Expecting top level dictionary but didn't find one")
+                return nil
+            }
+
+            return ActivityLogSection(rootJSON)
+        } catch {
+            debug("Error deserializing JSON: \(error)")
+            return nil
+        }
+    }
     
     public func getActionTestSummary(id: String) -> ActionTestSummary? {
         

--- a/Tests/XCResultKitTests/ActivityLogTests.swift
+++ b/Tests/XCResultKitTests/ActivityLogTests.swift
@@ -1,0 +1,1837 @@
+//
+//  ActivityLogTests.swift
+//  XCResultKitTests
+//
+//  Created by Pierre Felgines on 05/10/2019.
+//
+
+import Foundation
+import XCTest
+@testable import XCResultKit
+
+final class ActivityLogTests: XCTestCase {
+
+    func testCanParseCorrectlyFormattedJSON() {
+
+        let parsed = ActivityLogSection(parse(documentLocationJson))
+        XCTAssertNotNil(parsed)
+    }
+
+    static var allTests = [
+        ("testCanParseCorrectlyFormattedJSON", testCanParseCorrectlyFormattedJSON),
+    ]
+
+    private func parse(_ jsonData: String) -> [String: AnyObject] {
+
+        do {
+            guard let data = jsonData.data(using: .utf8) else {
+                fatalError("Unable to turn string into data, must not be a utf8 string")
+            }
+
+            guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
+                fatalError("Expecting top level dictionary but didn't find one")
+            }
+            return rootJSON
+        } catch {
+            fatalError("Error deserializing JSON: \(error)")
+        }
+    }
+
+    let documentLocationJson = """
+{
+  "_type" : {
+    "_name" : "ActivityLogSection"
+  },
+  "domainType" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "com.apple.dt.unit.cocoaUnitTest"
+  },
+  "duration" : {
+    "_type" : {
+      "_name" : "Double"
+    },
+    "_value" : "153.5236370563507"
+  },
+  "result" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "succeeded"
+  },
+  "startTime" : {
+    "_type" : {
+      "_name" : "Date"
+    },
+    "_value" : "2019-10-03T15:37:20.261+0200"
+  },
+  "subsections" : {
+    "_type" : {
+      "_name" : "Array"
+    },
+    "_values" : [
+      {
+        "_type" : {
+          "_name" : "ActivityLogMajorSection",
+          "_supertype" : {
+            "_name" : "ActivityLogSection"
+          }
+        },
+        "domainType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.unit.cocoaUnitTest"
+        },
+        "duration" : {
+          "_type" : {
+            "_name" : "Double"
+          },
+          "_value" : "44.572818994522095"
+        },
+        "result" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "succeeded"
+        },
+        "startTime" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2019-10-03T15:38:05.069+0200"
+        },
+        "subsections" : {
+          "_type" : {
+            "_name" : "Array"
+          },
+          "_values" : [
+            {
+              "_type" : {
+                "_name" : "ActivityLogUnitTestSection",
+                "_supertype" : {
+                  "_name" : "ActivityLogSection"
+                }
+              },
+              "domainType" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "com.apple.dt.IDE.UnitTestLogSection.Worker"
+              },
+              "duration" : {
+                "_type" : {
+                  "_name" : "Double"
+                },
+                "_value" : "41.27573120594025"
+              },
+              "emittedOutput" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "2019-10-03 15:38:07.850910+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.851025+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:07.872796+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.880342+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.880475+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:07.910883+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] Running tests...\\nTest Suite 'All tests' started at 2019-10-03 15:38:08.069\\nTest Suite 'XCTestHTMLReportSampleAppUITests.xctest' started at 2019-10-03 15:38:08.070\\nTest Suite 'FirstSuite' started at 2019-10-03 15:38:08.071\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\nTest Suite 'FirstSuite' passed at 2019-10-03 15:38:25.923.\\n\\t Executed 3 tests, with 0 failures (0 unexpected) in 17.851 (17.853) seconds\\nTest Suite 'SecondSuite' started at 2019-10-03 15:38:25.924\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:31.686\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83161\\n    t =     3.79s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.27s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\nTest Suite 'SecondSuite' failed at 2019-10-03 15:38:37.445.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 11.520 (11.521) seconds\\nTest Suite 'ThirdSuite' started at 2019-10-03 15:38:37.446\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:37.447\\n    t =     0.03s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83206\\n    t =     3.92s             Setting up automation session\\n    t =     4.46s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.67s test Activity - Success\\n    t =     5.67s test Activity - Failure\\n    t =     5.67s     Assertion Failure: ThirdSuite.swift:29: XCTAssertTrue failed - Test failed\\n    t =     5.72s test Activity with sub-activities\\n    t =     5.72s     test sub Activity 0 - Failure\\n    t =     5.72s         Assertion Failure: ThirdSuite.swift:33: XCTAssertTrue failed - Test failed\\n    t =     5.72s     test sub Activity 1 - Success\\n    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\nTest Suite 'ThirdSuite' failed at 2019-10-03 15:38:49.353.\\n\\t Executed 2 tests, with 3 failures (0 unexpected) in 11.905 (11.907) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUITests.xctest' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.284) seconds\\nTest Suite 'All tests' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.286) seconds\\n"
+              },
+              "result" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "succeeded"
+              },
+              "runnablePath" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "/Users/felginep/Library/Developer/Xcode/DerivedData/XCTestHTMLReportSampleApp-fmywasfnsjxoiucjtawjnsntkdkc/Build/Products/Debug-iphonesimulator/XCTestHTMLReportSampleAppUITests-Runner.app"
+              },
+              "runnableUTI" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "com.apple.application-bundle"
+              },
+              "startTime" : {
+                "_type" : {
+                  "_name" : "Date"
+                },
+                "_value" : "2019-10-03T15:38:05.069+0200"
+              },
+              "subsections" : {
+                "_type" : {
+                  "_name" : "Array"
+                },
+                "_values" : [
+                  {
+                    "_type" : {
+                      "_name" : "ActivityLogCommandInvocationSection",
+                      "_supertype" : {
+                        "_name" : "ActivityLogSection"
+                      }
+                    },
+                    "commandDetails" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUITests-B950CF55-4E02-414D-94A6-FCEE83520D4A/XCTestHTMLReportSampleAppUITests-91E1F09B-FA43-431B-ACDF-0FF86B852B5F/Session-XCTestHTMLReportSampleAppUITests-2019-10-03_153729-HNIPgP.log"
+                    },
+                    "domainType" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                    },
+                    "duration" : {
+                      "_type" : {
+                        "_name" : "Double"
+                      },
+                      "_value" : "7.796287536621094e-05"
+                    },
+                    "messages" : {
+                      "_type" : {
+                        "_name" : "Array"
+                      },
+                      "_values" : [
+                        {
+                          "_type" : {
+                            "_name" : "ActivityLogMessage"
+                          },
+                          "location" : {
+                            "_type" : {
+                              "_name" : "DocumentLocation"
+                            },
+                            "concreteTypeName" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "DVTTextDocumentLocation"
+                            },
+                            "url" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUITests-B950CF55-4E02-414D-94A6-FCEE83520D4A/XCTestHTMLReportSampleAppUITests-91E1F09B-FA43-431B-ACDF-0FF86B852B5F/Session-XCTestHTMLReportSampleAppUITests-2019-10-03_153729-HNIPgP.log#CharacterRangeLen=0"
+                            }
+                          },
+                          "shortTitle" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUITests-B950CF55-4E02-414D-94A6-FCEE83520D4A/XCTestHTMLReportSampleAppUITests-91E1F09B-FA43-431B-ACDF-0FF86B852B5F/Session-XCTestHTMLReportSampleAppUITests-2019-10-03_153729-HNIPgP.log"
+                          },
+                          "title" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUITests-B950CF55-4E02-414D-94A6-FCEE83520D4A/XCTestHTMLReportSampleAppUITests-91E1F09B-FA43-431B-ACDF-0FF86B852B5F/Session-XCTestHTMLReportSampleAppUITests-2019-10-03_153729-HNIPgP.log"
+                          },
+                          "type" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "notice"
+                          }
+                        }
+                      ]
+                    },
+                    "result" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "succeeded"
+                    },
+                    "startTime" : {
+                      "_type" : {
+                        "_name" : "Date"
+                      },
+                      "_value" : "2019-10-03T15:38:05.069+0200"
+                    },
+                    "title" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Writing diagnostic log for test session. Please attach this log to any test-related bug reports."
+                    }
+                  },
+                  {
+                    "_type" : {
+                      "_name" : "ActivityLogUnitTestSection",
+                      "_supertype" : {
+                        "_name" : "ActivityLogSection"
+                      }
+                    },
+                    "domainType" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                    },
+                    "duration" : {
+                      "_type" : {
+                        "_name" : "Double"
+                      },
+                      "_value" : "41.27573120594025"
+                    },
+                    "emittedOutput" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "2019-10-03 15:38:07.850910+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.851025+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:07.872796+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.880342+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:07.880475+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:07.910883+0200 XCTestHTMLReportSampleAppUITests-Runner[83084:14614693] Running tests...\\nTest Suite 'All tests' started at 2019-10-03 15:38:08.069\\nTest Suite 'XCTestHTMLReportSampleAppUITests.xctest' started at 2019-10-03 15:38:08.070\\nTest Suite 'FirstSuite' started at 2019-10-03 15:38:08.071\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\nTest Suite 'FirstSuite' passed at 2019-10-03 15:38:25.923.\\n\\t Executed 3 tests, with 0 failures (0 unexpected) in 17.851 (17.853) seconds\\nTest Suite 'SecondSuite' started at 2019-10-03 15:38:25.924\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:31.686\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83161\\n    t =     3.79s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.27s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\nTest Suite 'SecondSuite' failed at 2019-10-03 15:38:37.445.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 11.520 (11.521) seconds\\nTest Suite 'ThirdSuite' started at 2019-10-03 15:38:37.446\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:37.447\\n    t =     0.03s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83206\\n    t =     3.92s             Setting up automation session\\n    t =     4.46s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.67s test Activity - Success\\n    t =     5.67s test Activity - Failure\\n    t =     5.67s     Assertion Failure: ThirdSuite.swift:29: XCTAssertTrue failed - Test failed\\n    t =     5.72s test Activity with sub-activities\\n    t =     5.72s     test sub Activity 0 - Failure\\n    t =     5.72s         Assertion Failure: ThirdSuite.swift:33: XCTAssertTrue failed - Test failed\\n    t =     5.72s     test sub Activity 1 - Success\\n    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\nTest Suite 'ThirdSuite' failed at 2019-10-03 15:38:49.353.\\n\\t Executed 2 tests, with 3 failures (0 unexpected) in 11.905 (11.907) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUITests.xctest' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.284) seconds\\nTest Suite 'All tests' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.286) seconds\\n"
+                    },
+                    "result" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "succeeded"
+                    },
+                    "startTime" : {
+                      "_type" : {
+                        "_name" : "Date"
+                      },
+                      "_value" : "2019-10-03T15:38:08.071+0200"
+                    },
+                    "subsections" : {
+                      "_type" : {
+                        "_name" : "Array"
+                      },
+                      "_values" : [
+                        {
+                          "_type" : {
+                            "_name" : "ActivityLogUnitTestSection",
+                            "_supertype" : {
+                              "_name" : "ActivityLogSection"
+                            }
+                          },
+                          "domainType" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                          },
+                          "duration" : {
+                            "_type" : {
+                              "_name" : "Double"
+                            },
+                            "_value" : "41.27573120594025"
+                          },
+                          "emittedOutput" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Test Suite 'XCTestHTMLReportSampleAppUITests.xctest' started at 2019-10-03 15:38:08.070\\nTest Suite 'FirstSuite' started at 2019-10-03 15:38:08.071\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\nTest Suite 'FirstSuite' passed at 2019-10-03 15:38:25.923.\\n\\t Executed 3 tests, with 0 failures (0 unexpected) in 17.851 (17.853) seconds\\nTest Suite 'SecondSuite' started at 2019-10-03 15:38:25.924\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:31.686\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83161\\n    t =     3.79s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.27s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\nTest Suite 'SecondSuite' failed at 2019-10-03 15:38:37.445.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 11.520 (11.521) seconds\\nTest Suite 'ThirdSuite' started at 2019-10-03 15:38:37.446\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:37.447\\n    t =     0.03s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83206\\n    t =     3.92s             Setting up automation session\\n    t =     4.46s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.67s test Activity - Success\\n    t =     5.67s test Activity - Failure\\n    t =     5.67s     Assertion Failure: ThirdSuite.swift:29: XCTAssertTrue failed - Test failed\\n    t =     5.72s test Activity with sub-activities\\n    t =     5.72s     test sub Activity 0 - Failure\\n    t =     5.72s         Assertion Failure: ThirdSuite.swift:33: XCTAssertTrue failed - Test failed\\n    t =     5.72s     test sub Activity 1 - Success\\n    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\nTest Suite 'ThirdSuite' failed at 2019-10-03 15:38:49.353.\\n\\t Executed 2 tests, with 3 failures (0 unexpected) in 11.905 (11.907) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUITests.xctest' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.284) seconds\\n"
+                          },
+                          "result" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "succeeded"
+                          },
+                          "startTime" : {
+                            "_type" : {
+                              "_name" : "Date"
+                            },
+                            "_value" : "2019-10-03T15:38:08.072+0200"
+                          },
+                          "subsections" : {
+                            "_type" : {
+                              "_name" : "Array"
+                            },
+                            "_values" : [
+                              {
+                                "_type" : {
+                                  "_name" : "ActivityLogUnitTestSection",
+                                  "_supertype" : {
+                                    "_name" : "ActivityLogSection"
+                                  }
+                                },
+                                "domainType" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                },
+                                "duration" : {
+                                  "_type" : {
+                                    "_name" : "Double"
+                                  },
+                                  "_value" : "17.850802063941956"
+                                },
+                                "emittedOutput" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'FirstSuite' started at 2019-10-03 15:38:08.071\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\nTest Suite 'FirstSuite' passed at 2019-10-03 15:38:25.923.\\n\\t Executed 3 tests, with 0 failures (0 unexpected) in 17.851 (17.853) seconds\\n"
+                                },
+                                "result" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "succeeded"
+                                },
+                                "startTime" : {
+                                  "_type" : {
+                                    "_name" : "Date"
+                                  },
+                                  "_value" : "2019-10-03T15:38:08.072+0200"
+                                },
+                                "subsections" : {
+                                  "_type" : {
+                                    "_name" : "Array"
+                                  },
+                                  "_values" : [
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "6.231536030769348"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:08.075+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "FirstSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     0.00s Start Test at 2019-10-03 15:38:08.072\\n    t =     0.07s Set Up\\n    t =     0.08s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.14s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     3.67s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.66s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     6.01s Added attachment named 'HTML'\\n    t =     6.01s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testDownloadAndAttachWebData]' passed (6.232 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testDownloadAndAttachWebData()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testDownloadAndAttachWebData()"
+                                      }
+                                    },
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.911841034889221"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:14.307+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "FirstSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     0.00s Start Test at 2019-10-03 15:38:14.304\\n    t =     0.06s Set Up\\n    t =     0.06s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.10s             Terminate com.tito.XCTestHTMLReportSampleApp:83089\\n    t =     4.03s             Wait for accessibility to load\\n    t =     4.15s             Setting up automation session\\n    t =     4.49s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.71s Text Attachment\\n    t =     5.71s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testOne]' passed (5.912 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testOne()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testOne()"
+                                      }
+                                    },
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.707424998283386"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:20.219+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "FirstSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     0.00s Start Test at 2019-10-03 15:38:20.216\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.09s             Terminate com.tito.XCTestHTMLReportSampleApp:83092\\n    t =     4.06s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.50s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.FirstSuite testTwo]' passed (5.707 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testTwo()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testTwo()"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "suiteName" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "FirstSuite"
+                                },
+                                "summary" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'FirstSuite' passed at 2019-10-03 15:38:25.923.\\n\\t Executed 3 tests, with 0 failures (0 unexpected) in 17.851 (17.853) seconds\\n"
+                                },
+                                "testsPassedString" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "3 out of 3 tests passed"
+                                },
+                                "title" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Run test suite FirstSuite"
+                                }
+                              },
+                              {
+                                "_type" : {
+                                  "_name" : "ActivityLogUnitTestSection",
+                                  "_supertype" : {
+                                    "_name" : "ActivityLogSection"
+                                  }
+                                },
+                                "domainType" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                },
+                                "duration" : {
+                                  "_type" : {
+                                    "_name" : "Double"
+                                  },
+                                  "_value" : "11.52010202407837"
+                                },
+                                "emittedOutput" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'SecondSuite' started at 2019-10-03 15:38:25.924\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:31.686\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83161\\n    t =     3.79s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.27s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\nTest Suite 'SecondSuite' failed at 2019-10-03 15:38:37.445.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 11.520 (11.521) seconds\\n"
+                                },
+                                "result" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "succeeded"
+                                },
+                                "startTime" : {
+                                  "_type" : {
+                                    "_name" : "Date"
+                                  },
+                                  "_value" : "2019-10-03T15:38:25.926+0200"
+                                },
+                                "subsections" : {
+                                  "_type" : {
+                                    "_name" : "Array"
+                                  },
+                                  "_values" : [
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.761072993278503"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:25.927+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "SecondSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     0.00s Start Test at 2019-10-03 15:38:25.925\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83094\\n    t =     4.05s             Wait for accessibility to load\\n    t =     4.16s             Setting up automation session\\n    t =     4.24s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.56s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testOne]' passed (5.761 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testOne()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testOne()"
+                                      }
+                                    },
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.759029030799866"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:31.686\\n    t =     0.04s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83161\\n    t =     3.79s             Wait for accessibility to load\\n    t =     3.92s             Setting up automation session\\n    t =     4.27s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\n"
+                                      },
+                                      "messages" : {
+                                        "_type" : {
+                                          "_name" : "Array"
+                                        },
+                                        "_values" : [
+                                          {
+                                            "_type" : {
+                                              "_name" : "ActivityLogMessage"
+                                            },
+                                            "location" : {
+                                              "_type" : {
+                                                "_name" : "DocumentLocation"
+                                              },
+                                              "concreteTypeName" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "DVTTextDocumentLocation"
+                                              },
+                                              "url" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/SecondSuite.swift#CharacterRangeLen=0&EndingLineNumber=37&StartingLineNumber=37"
+                                              }
+                                            },
+                                            "shortTitle" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "title" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "type" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "test failure"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:31.689+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "SecondSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     5.72s Assertion Failure: SecondSuite.swift:38: XCTAssertTrue failed - Test failed\\n    t =     5.76s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.SecondSuite testTwo]' failed (5.759 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testTwo()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testTwo()"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "suiteName" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "SecondSuite"
+                                },
+                                "summary" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'SecondSuite' failed at 2019-10-03 15:38:37.445.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 11.520 (11.521) seconds\\n"
+                                },
+                                "testsPassedString" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "1 out of 2 tests passed"
+                                },
+                                "title" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Run test suite SecondSuite"
+                                }
+                              },
+                              {
+                                "_type" : {
+                                  "_name" : "ActivityLogUnitTestSection",
+                                  "_supertype" : {
+                                    "_name" : "ActivityLogSection"
+                                  }
+                                },
+                                "domainType" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                },
+                                "duration" : {
+                                  "_type" : {
+                                    "_name" : "Double"
+                                  },
+                                  "_value" : "11.904827117919922"
+                                },
+                                "emittedOutput" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'ThirdSuite' started at 2019-10-03 15:38:37.446\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:37.447\\n    t =     0.03s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83206\\n    t =     3.92s             Setting up automation session\\n    t =     4.46s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.67s test Activity - Success\\n    t =     5.67s test Activity - Failure\\n    t =     5.67s     Assertion Failure: ThirdSuite.swift:29: XCTAssertTrue failed - Test failed\\n    t =     5.72s test Activity with sub-activities\\n    t =     5.72s     test sub Activity 0 - Failure\\n    t =     5.72s         Assertion Failure: ThirdSuite.swift:33: XCTAssertTrue failed - Test failed\\n    t =     5.72s     test sub Activity 1 - Success\\n    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\nTest Suite 'ThirdSuite' failed at 2019-10-03 15:38:49.353.\\n\\t Executed 2 tests, with 3 failures (0 unexpected) in 11.905 (11.907) seconds\\n"
+                                },
+                                "result" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "succeeded"
+                                },
+                                "startTime" : {
+                                  "_type" : {
+                                    "_name" : "Date"
+                                  },
+                                  "_value" : "2019-10-03T15:38:37.449+0200"
+                                },
+                                "subsections" : {
+                                  "_type" : {
+                                    "_name" : "Array"
+                                  },
+                                  "_values" : [
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.928067088127136"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:37.447\\n    t =     0.03s Set Up\\n    t =     0.04s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.07s             Terminate com.tito.XCTestHTMLReportSampleApp:83206\\n    t =     3.92s             Setting up automation session\\n    t =     4.46s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.67s test Activity - Success\\n    t =     5.67s test Activity - Failure\\n    t =     5.67s     Assertion Failure: ThirdSuite.swift:29: XCTAssertTrue failed - Test failed\\n    t =     5.72s test Activity with sub-activities\\n    t =     5.72s     test sub Activity 0 - Failure\\n    t =     5.72s         Assertion Failure: ThirdSuite.swift:33: XCTAssertTrue failed - Test failed\\n    t =     5.72s     test sub Activity 1 - Success\\n    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\n"
+                                      },
+                                      "messages" : {
+                                        "_type" : {
+                                          "_name" : "Array"
+                                        },
+                                        "_values" : [
+                                          {
+                                            "_type" : {
+                                              "_name" : "ActivityLogMessage"
+                                            },
+                                            "location" : {
+                                              "_type" : {
+                                                "_name" : "DocumentLocation"
+                                              },
+                                              "concreteTypeName" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "DVTTextDocumentLocation"
+                                              },
+                                              "url" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/ThirdSuite.swift#CharacterRangeLen=0&EndingLineNumber=28&StartingLineNumber=28"
+                                              }
+                                            },
+                                            "shortTitle" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "title" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "type" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "test failure"
+                                            }
+                                          },
+                                          {
+                                            "_type" : {
+                                              "_name" : "ActivityLogMessage"
+                                            },
+                                            "location" : {
+                                              "_type" : {
+                                                "_name" : "DocumentLocation"
+                                              },
+                                              "concreteTypeName" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "DVTTextDocumentLocation"
+                                              },
+                                              "url" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/ThirdSuite.swift#CharacterRangeLen=0&EndingLineNumber=32&StartingLineNumber=32"
+                                              }
+                                            },
+                                            "shortTitle" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "title" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "type" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "test failure"
+                                            }
+                                          },
+                                          {
+                                            "_type" : {
+                                              "_name" : "ActivityLogMessage"
+                                            },
+                                            "location" : {
+                                              "_type" : {
+                                                "_name" : "DocumentLocation"
+                                              },
+                                              "concreteTypeName" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "DVTTextDocumentLocation"
+                                              },
+                                              "url" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/ThirdSuite.swift#CharacterRangeLen=0&EndingLineNumber=38&StartingLineNumber=38"
+                                              }
+                                            },
+                                            "shortTitle" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "title" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "type" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "test failure"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:37.449+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "ThirdSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     5.72s Assertion Failure: ThirdSuite.swift:39: XCTAssertTrue failed - Test failed\\n    t =     5.72s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testOne]' failed (5.928 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testOne()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testOne()"
+                                      }
+                                    },
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "5.976760029792786"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' started.\\n    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:43.378+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "ThirdSuite"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "    t =     0.00s Start Test at 2019-10-03 15:38:43.376\\n    t =     0.05s Set Up\\n    t =     0.05s     Open com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s         Launch com.tito.XCTestHTMLReportSampleApp\\n    t =     0.08s             Terminate com.tito.XCTestHTMLReportSampleApp:83209\\n    t =     3.88s             Setting up automation session\\n    t =     4.29s             Wait for com.tito.XCTestHTMLReportSampleApp to idle\\n    t =     5.77s Tear Down\\nTest Case '-[XCTestHTMLReportSampleAppUITests.ThirdSuite testTwo]' passed (5.977 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testTwo()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testTwo()"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "suiteName" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "ThirdSuite"
+                                },
+                                "summary" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'ThirdSuite' failed at 2019-10-03 15:38:49.353.\\n\\t Executed 2 tests, with 3 failures (0 unexpected) in 11.905 (11.907) seconds\\n"
+                                },
+                                "testsPassedString" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "1 out of 2 tests passed"
+                                },
+                                "title" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Run test suite ThirdSuite"
+                                }
+                              }
+                            ]
+                          },
+                          "suiteName" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "XCTestHTMLReportSampleAppUITests.xctest"
+                          },
+                          "summary" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Test Suite 'XCTestHTMLReportSampleAppUITests.xctest' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.284) seconds\\n"
+                          },
+                          "testsPassedString" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "5 out of 7 tests passed"
+                          },
+                          "title" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Run test suite XCTestHTMLReportSampleAppUITests.xctest"
+                          }
+                        }
+                      ]
+                    },
+                    "suiteName" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "All tests"
+                    },
+                    "summary" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Test Suite 'All tests' failed at 2019-10-03 15:38:49.354.\\n\\t Executed 7 tests, with 4 failures (0 unexpected) in 41.276 (41.286) seconds\\n"
+                    },
+                    "testsPassedString" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "5 out of 7 tests passed"
+                    },
+                    "title" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Run test suite All tests"
+                    }
+                  }
+                ]
+              },
+              "testsPassedString" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "5 out of 7 tests passed"
+              },
+              "title" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "XCTestHTMLReportSampleAppUITests-Runner.app (83084)"
+              }
+            }
+          ]
+        },
+        "subtitle" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Destination iPhone Xs Max"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Test target XCTestHTMLReportSampleAppUITests"
+        }
+      },
+      {
+        "_type" : {
+          "_name" : "ActivityLogMajorSection",
+          "_supertype" : {
+            "_name" : "ActivityLogSection"
+          }
+        },
+        "domainType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.unit.cocoaUnitTest"
+        },
+        "duration" : {
+          "_type" : {
+            "_name" : "Double"
+          },
+          "_value" : "4.515720009803772"
+        },
+        "result" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "succeeded"
+        },
+        "startTime" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2019-10-03T15:38:49.699+0200"
+        },
+        "subsections" : {
+          "_type" : {
+            "_name" : "Array"
+          },
+          "_values" : [
+            {
+              "_type" : {
+                "_name" : "ActivityLogUnitTestSection",
+                "_supertype" : {
+                  "_name" : "ActivityLogSection"
+                }
+              },
+              "domainType" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "com.apple.dt.IDE.UnitTestLogSection.Worker"
+              },
+              "duration" : {
+                "_type" : {
+                  "_name" : "Double"
+                },
+                "_value" : "0.017937898635864258"
+              },
+              "emittedOutput" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "2019-10-03 15:38:53.116540+0200 XCTestHTMLReportSampleApp[83223:14616367] Launching with XCTest injected. Preparing to run tests.\\n2019-10-03 15:38:53.133393+0200 XCTestHTMLReportSampleApp[83223:14616367] Waiting to run tests until the app finishes launching.\\n2019-10-03 15:38:53.367161+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.367299+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:53.404716+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.413360+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.414159+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unexpected physical screen orientation\\nTest Suite 'All tests' started at 2019-10-03 15:38:53.835\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' started at 2019-10-03 15:38:53.838\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' started at 2019-10-03 15:38:53.840\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' started.\\n/Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift:15: error: -[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure] : XCTAssertTrue failed - Test failed\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' started.\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' failed at 2019-10-03 15:38:53.861.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.020) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.024) seconds\\nTest Suite 'All tests' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.028) seconds\\n"
+              },
+              "result" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "succeeded"
+              },
+              "runnablePath" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "/Users/felginep/Library/Developer/Xcode/DerivedData/XCTestHTMLReportSampleApp-fmywasfnsjxoiucjtawjnsntkdkc/Build/Products/Debug-iphonesimulator/XCTestHTMLReportSampleApp.app"
+              },
+              "runnableUTI" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "com.apple.application-bundle"
+              },
+              "startTime" : {
+                "_type" : {
+                  "_name" : "Date"
+                },
+                "_value" : "2019-10-03T15:38:49.699+0200"
+              },
+              "subsections" : {
+                "_type" : {
+                  "_name" : "Array"
+                },
+                "_values" : [
+                  {
+                    "_type" : {
+                      "_name" : "ActivityLogCommandInvocationSection",
+                      "_supertype" : {
+                        "_name" : "ActivityLogSection"
+                      }
+                    },
+                    "commandDetails" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUnitTests-6F422EE2-0C31-488E-ADE9-5A3AC9C085BB/XCTestHTMLReportSampleAppUnitTests-7AD3AEC4-E477-48C0-9804-00ED8A335656/Session-XCTestHTMLReportSampleAppUnitTests-2019-10-03_153849-FzLc7W.log"
+                    },
+                    "domainType" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                    },
+                    "duration" : {
+                      "_type" : {
+                        "_name" : "Double"
+                      },
+                      "_value" : "7.700920104980469e-05"
+                    },
+                    "messages" : {
+                      "_type" : {
+                        "_name" : "Array"
+                      },
+                      "_values" : [
+                        {
+                          "_type" : {
+                            "_name" : "ActivityLogMessage"
+                          },
+                          "location" : {
+                            "_type" : {
+                              "_name" : "DocumentLocation"
+                            },
+                            "concreteTypeName" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "DVTTextDocumentLocation"
+                            },
+                            "url" : {
+                              "_type" : {
+                                "_name" : "String"
+                              },
+                              "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUnitTests-6F422EE2-0C31-488E-ADE9-5A3AC9C085BB/XCTestHTMLReportSampleAppUnitTests-7AD3AEC4-E477-48C0-9804-00ED8A335656/Session-XCTestHTMLReportSampleAppUnitTests-2019-10-03_153849-FzLc7W.log#CharacterRangeLen=0"
+                            }
+                          },
+                          "shortTitle" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUnitTests-6F422EE2-0C31-488E-ADE9-5A3AC9C085BB/XCTestHTMLReportSampleAppUnitTests-7AD3AEC4-E477-48C0-9804-00ED8A335656/Session-XCTestHTMLReportSampleAppUnitTests-2019-10-03_153849-FzLc7W.log"
+                          },
+                          "title" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "/Users/felginep/Sources/XCTestHTMLReport/TestResultsB/Staging/1_Test/Diagnostics/XCTestHTMLReportSampleAppUnitTests-6F422EE2-0C31-488E-ADE9-5A3AC9C085BB/XCTestHTMLReportSampleAppUnitTests-7AD3AEC4-E477-48C0-9804-00ED8A335656/Session-XCTestHTMLReportSampleAppUnitTests-2019-10-03_153849-FzLc7W.log"
+                          },
+                          "type" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "notice"
+                          }
+                        }
+                      ]
+                    },
+                    "result" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "succeeded"
+                    },
+                    "startTime" : {
+                      "_type" : {
+                        "_name" : "Date"
+                      },
+                      "_value" : "2019-10-03T15:38:49.699+0200"
+                    },
+                    "title" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Writing diagnostic log for test session. Please attach this log to any test-related bug reports."
+                    }
+                  },
+                  {
+                    "_type" : {
+                      "_name" : "ActivityLogUnitTestSection",
+                      "_supertype" : {
+                        "_name" : "ActivityLogSection"
+                      }
+                    },
+                    "domainType" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                    },
+                    "duration" : {
+                      "_type" : {
+                        "_name" : "Double"
+                      },
+                      "_value" : "0.017937898635864258"
+                    },
+                    "emittedOutput" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "2019-10-03 15:38:53.116540+0200 XCTestHTMLReportSampleApp[83223:14616367] Launching with XCTest injected. Preparing to run tests.\\n2019-10-03 15:38:53.133393+0200 XCTestHTMLReportSampleApp[83223:14616367] Waiting to run tests until the app finishes launching.\\n2019-10-03 15:38:53.367161+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.367299+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unexpected physical screen orientation\\n2019-10-03 15:38:53.404716+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.413360+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unable to look up screen scale\\n2019-10-03 15:38:53.414159+0200 XCTestHTMLReportSampleApp[83223:14616367] [AXMediaCommon] Unexpected physical screen orientation\\nTest Suite 'All tests' started at 2019-10-03 15:38:53.835\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' started at 2019-10-03 15:38:53.838\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' started at 2019-10-03 15:38:53.840\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' started.\\n/Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift:15: error: -[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure] : XCTAssertTrue failed - Test failed\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' started.\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' failed at 2019-10-03 15:38:53.861.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.020) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.024) seconds\\nTest Suite 'All tests' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.028) seconds\\n"
+                    },
+                    "result" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "succeeded"
+                    },
+                    "startTime" : {
+                      "_type" : {
+                        "_name" : "Date"
+                      },
+                      "_value" : "2019-10-03T15:38:53.839+0200"
+                    },
+                    "subsections" : {
+                      "_type" : {
+                        "_name" : "Array"
+                      },
+                      "_values" : [
+                        {
+                          "_type" : {
+                            "_name" : "ActivityLogUnitTestSection",
+                            "_supertype" : {
+                              "_name" : "ActivityLogSection"
+                            }
+                          },
+                          "domainType" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                          },
+                          "duration" : {
+                            "_type" : {
+                              "_name" : "Double"
+                            },
+                            "_value" : "0.017937898635864258"
+                          },
+                          "emittedOutput" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Test Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' started at 2019-10-03 15:38:53.838\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' started at 2019-10-03 15:38:53.840\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' started.\\n/Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift:15: error: -[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure] : XCTAssertTrue failed - Test failed\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' started.\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' failed at 2019-10-03 15:38:53.861.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.020) seconds\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.024) seconds\\n"
+                          },
+                          "result" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "succeeded"
+                          },
+                          "startTime" : {
+                            "_type" : {
+                              "_name" : "Date"
+                            },
+                            "_value" : "2019-10-03T15:38:53.842+0200"
+                          },
+                          "subsections" : {
+                            "_type" : {
+                              "_name" : "Array"
+                            },
+                            "_values" : [
+                              {
+                                "_type" : {
+                                  "_name" : "ActivityLogUnitTestSection",
+                                  "_supertype" : {
+                                    "_name" : "ActivityLogSection"
+                                  }
+                                },
+                                "domainType" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                },
+                                "duration" : {
+                                  "_type" : {
+                                    "_name" : "Double"
+                                  },
+                                  "_value" : "0.017937898635864258"
+                                },
+                                "emittedOutput" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'XCTestHTMLReportSampleAppUnitTests' started at 2019-10-03 15:38:53.840\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' started.\\n/Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift:15: error: -[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure] : XCTAssertTrue failed - Test failed\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' started.\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\nTest Suite 'XCTestHTMLReportSampleAppUnitTests' failed at 2019-10-03 15:38:53.861.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.020) seconds\\n"
+                                },
+                                "result" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "succeeded"
+                                },
+                                "startTime" : {
+                                  "_type" : {
+                                    "_name" : "Date"
+                                  },
+                                  "_value" : "2019-10-03T15:38:53.843+0200"
+                                },
+                                "subsections" : {
+                                  "_type" : {
+                                    "_name" : "Array"
+                                  },
+                                  "_values" : [
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "0.017200946807861328"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' started.\\n/Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift:15: error: -[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure] : XCTAssertTrue failed - Test failed\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\n"
+                                      },
+                                      "messages" : {
+                                        "_type" : {
+                                          "_name" : "Array"
+                                        },
+                                        "_values" : [
+                                          {
+                                            "_type" : {
+                                              "_name" : "ActivityLogMessage"
+                                            },
+                                            "location" : {
+                                              "_type" : {
+                                                "_name" : "DocumentLocation"
+                                              },
+                                              "concreteTypeName" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "DVTTextDocumentLocation"
+                                              },
+                                              "url" : {
+                                                "_type" : {
+                                                  "_name" : "String"
+                                                },
+                                                "_value" : "file:///Users/felginep/Sources/XCTestHTMLReport/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUnitTests/XCTestHTMLReportSampleAppUnitTests.swift#CharacterRangeLen=0&EndingLineNumber=14&StartingLineNumber=14"
+                                              }
+                                            },
+                                            "shortTitle" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "title" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "XCTAssertTrue failed - Test failed"
+                                            },
+                                            "type" : {
+                                              "_type" : {
+                                                "_name" : "String"
+                                              },
+                                              "_value" : "test failure"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:53.864+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "XCTestHTMLReportSampleAppUnitTests"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testFailure]' failed (0.017 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testFailure()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testFailure()"
+                                      }
+                                    },
+                                    {
+                                      "_type" : {
+                                        "_name" : "ActivityLogUnitTestSection",
+                                        "_supertype" : {
+                                          "_name" : "ActivityLogSection"
+                                        }
+                                      },
+                                      "domainType" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "com.apple.dt.IDE.UnitTestLogSection"
+                                      },
+                                      "duration" : {
+                                        "_type" : {
+                                          "_name" : "Double"
+                                        },
+                                        "_value" : "0.0007369518280029297"
+                                      },
+                                      "emittedOutput" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' started.\\nTest Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\n"
+                                      },
+                                      "result" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "succeeded"
+                                      },
+                                      "startTime" : {
+                                        "_type" : {
+                                          "_name" : "Date"
+                                        },
+                                        "_value" : "2019-10-03T15:38:53.865+0200"
+                                      },
+                                      "suiteName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "XCTestHTMLReportSampleAppUnitTests"
+                                      },
+                                      "summary" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Test Case '-[XCTestHTMLReportSampleAppUnitTests.XCTestHTMLReportSampleAppUnitTests testSuccess]' passed (0.001 seconds).\\n"
+                                      },
+                                      "testName" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "testSuccess()"
+                                      },
+                                      "title" : {
+                                        "_type" : {
+                                          "_name" : "String"
+                                        },
+                                        "_value" : "Run test case testSuccess()"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "suiteName" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "XCTestHTMLReportSampleAppUnitTests"
+                                },
+                                "summary" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Test Suite 'XCTestHTMLReportSampleAppUnitTests' failed at 2019-10-03 15:38:53.861.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.020) seconds\\n"
+                                },
+                                "testsPassedString" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "1 out of 2 tests passed"
+                                },
+                                "title" : {
+                                  "_type" : {
+                                    "_name" : "String"
+                                  },
+                                  "_value" : "Run test suite XCTestHTMLReportSampleAppUnitTests"
+                                }
+                              }
+                            ]
+                          },
+                          "suiteName" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "XCTestHTMLReportSampleAppUnitTests.xctest"
+                          },
+                          "summary" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Test Suite 'XCTestHTMLReportSampleAppUnitTests.xctest' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.024) seconds\\n"
+                          },
+                          "testsPassedString" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "1 out of 2 tests passed"
+                          },
+                          "title" : {
+                            "_type" : {
+                              "_name" : "String"
+                            },
+                            "_value" : "Run test suite XCTestHTMLReportSampleAppUnitTests.xctest"
+                          }
+                        }
+                      ]
+                    },
+                    "suiteName" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "All tests"
+                    },
+                    "summary" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Test Suite 'All tests' failed at 2019-10-03 15:38:53.862.\\n\\t Executed 2 tests, with 1 failure (0 unexpected) in 0.018 (0.028) seconds\\n"
+                    },
+                    "testsPassedString" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "1 out of 2 tests passed"
+                    },
+                    "title" : {
+                      "_type" : {
+                        "_name" : "String"
+                      },
+                      "_value" : "Run test suite All tests"
+                    }
+                  }
+                ]
+              },
+              "testsPassedString" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "1 out of 2 tests passed"
+              },
+              "title" : {
+                "_type" : {
+                  "_name" : "String"
+                },
+                "_value" : "XCTestHTMLReportSampleApp.app (83223)"
+              }
+            }
+          ]
+        },
+        "subtitle" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Destination iPhone Xs Max"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Test target XCTestHTMLReportSampleAppUnitTests"
+        }
+      }
+    ]
+  },
+  "title" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "Test XCTestHTMLReportSampleApp"
+  }
+}
+"""
+}


### PR DESCRIPTION
Add missing `ActivityLog...` files from the documentation.

Some properties (from `ActivityLogSection` mostly) are duplicated across other models because of the use of structs in the projet and the use of subclasses in the documentation. But it seems that you already did the same (for example in `TestFailureIssueSummary`).