### PR TITLE
♻️ Renamed debug method to logError

### DIFF
--- a/Sources/XCResultKit/ActionDeviceRecord.swift
+++ b/Sources/XCResultKit/ActionDeviceRecord.swift
@@ -69,7 +69,7 @@ public struct ActionDeviceRecord: XCResultObject {
             logicalCPUCoresPerPackage = xcOptional(element: "logicalCPUCoresPerPackage", from: json)
             platformRecord = try xcRequired(element: "platformRecord", from: json)
         } catch {
-            debug("Error parsing ActionDeviceRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionDeviceRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionPlatformRecord.swift
+++ b/Sources/XCResultKit/ActionPlatformRecord.swift
@@ -21,7 +21,7 @@ public struct ActionPlatformRecord: XCResultObject {
             identifier = try xcRequired(element: "identifier", from: json)
             userDescription = try xcRequired(element: "userDescription", from: json)
         } catch {
-            debug("Error parsing ActionPlatformRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionPlatformRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionRecord.swift
+++ b/Sources/XCResultKit/ActionRecord.swift
@@ -40,7 +40,7 @@ public struct ActionRecord: XCResultObject {
             endedTime = try xcRequired(element: "endedTime", from: json)
             runDestination = try xcRequired(element: "runDestination", from: json)
         } catch {
-            debug("Error parsing ActionRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionResult.swift
+++ b/Sources/XCResultKit/ActionResult.swift
@@ -43,7 +43,7 @@ public struct ActionResult: XCResultObject {
             testsRef = xcOptional(element: "testsRef", from: json)
             diagnosticsRef = xcOptional(element: "diagnosticsRef", from: json)
         } catch {
-            debug("Error parsing ActionResult: \(error.localizedDescription)")
+            logError("Error parsing ActionResult: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionRunDestinationRecord.swift
+++ b/Sources/XCResultKit/ActionRunDestinationRecord.swift
@@ -31,7 +31,7 @@ public struct ActionRunDestinationRecord: XCResultObject {
             localComputerRecord = try xcRequired(element: "localComputerRecord", from: json)
             targetSDKRecord = try xcRequired(element: "targetSDKRecord", from: json)
         } catch {
-            debug("Error parsing ActionRunDestinationRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionRunDestinationRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionSDKRecord.swift
+++ b/Sources/XCResultKit/ActionSDKRecord.swift
@@ -27,7 +27,7 @@ public struct ActionSDKRecord: XCResultObject {
             operatingSystemVersion = try xcRequired(element: "operatingSystemVersion", from: json)
             isInternal = xcOptional(element: "isInternal", from: json)
         } catch {
-            debug("Error parsing ActionSDKRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionSDKRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestActivitySummary.swift
+++ b/Sources/XCResultKit/ActionTestActivitySummary.swift
@@ -39,7 +39,7 @@ public struct ActionTestActivitySummary: XCResultObject {
             subactivities = xcArray(element: "subactivities", from: json)
                 .ofType(ActionTestActivitySummary.self)
         } catch {
-            debug("Error parsing ActionTestActivitySummary: \(error.localizedDescription)")
+            logError("Error parsing ActionTestActivitySummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestAttachment.swift
+++ b/Sources/XCResultKit/ActionTestAttachment.swift
@@ -41,7 +41,7 @@ public struct ActionTestAttachment: XCResultObject {
             payloadRef = xcOptional(element: "payloadRef", from: json)
             payloadSize = try xcRequired(element: "payloadSize", from: json)
         } catch {
-            debug("Error parsing ActionTestAttachment: \(error.localizedDescription)")
+            logError("Error parsing ActionTestAttachment: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestFailureSummary.swift
+++ b/Sources/XCResultKit/ActionTestFailureSummary.swift
@@ -28,7 +28,7 @@ public struct ActionTestFailureSummary: XCResultObject {
             lineNumber = xcOptional(element: "lineNumber", from: json) ?? 0
             isPerformanceFailure = xcOptional(element: "isPerformanceFailure", from: json) ?? false
         } catch {
-            debug("Error parsing ActionTestFailureSummary: \(error.localizedDescription)")
+            logError("Error parsing ActionTestFailureSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestMetadata.swift
+++ b/Sources/XCResultKit/ActionTestMetadata.swift
@@ -38,7 +38,7 @@ public struct ActionTestMetadata: XCResultObject {
             failureSummariesCount = xcOptional(element: "failureSummariesCount", from: json)
             activitySummariesCount = xcOptional(element: "activitySummariesCount", from: json)
         } catch {
-            debug("Error parsing ActionTestMetadata: \(error.localizedDescription)")
+            logError("Error parsing ActionTestMetadata: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestPerformanceMetricSummary.swift
+++ b/Sources/XCResultKit/ActionTestPerformanceMetricSummary.swift
@@ -45,7 +45,7 @@ public struct ActionTestPerformanceMetricSummary: XCResultObject {
             maxRegression = xcOptional(element: "maxRegression", from: json)
             maxStandardDeviation = xcOptional(element: "maxStandardDeviation", from: json)
         } catch {
-            debug("Error parsing ActionTestPerformanceMetricSummary: \(error.localizedDescription)")
+            logError("Error parsing ActionTestPerformanceMetricSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestPlanRunSummary.swift
+++ b/Sources/XCResultKit/ActionTestPlanRunSummary.swift
@@ -21,7 +21,7 @@ public struct ActionTestPlanRunSummary: XCResultObject {
             name = try xcRequired(element: "name", from: json)
             testableSummaries = xcArray(element: "testableSummaries", from: json).ofType(ActionTestableSummary.self)
         } catch {
-            debug("Error parsing ActionTestPlanRunSummary: \(error.localizedDescription)")
+            logError("Error parsing ActionTestPlanRunSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestSummary.swift
+++ b/Sources/XCResultKit/ActionTestSummary.swift
@@ -39,7 +39,7 @@ public struct ActionTestSummary: XCResultObject {
             activitySummaries = xcArray(element: "activitySummaries", from: json)
                 .ofType(ActionTestActivitySummary.self)
         } catch {
-            debug("Error parsing ActionTestSummary: \(error.localizedDescription)")
+            logError("Error parsing ActionTestSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionTestSummaryGroup.swift
+++ b/Sources/XCResultKit/ActionTestSummaryGroup.swift
@@ -30,7 +30,7 @@ public struct ActionTestSummaryGroup: XCResultObject {
             subtests = xcArray(element: "subtests", from: json)
                 .ofType(ActionTestMetadata.self)
         } catch {
-            debug("Error parsing ActionTestSummaryGroup: \(error.localizedDescription)")
+            logError("Error parsing ActionTestSummaryGroup: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActionsInvocationRecord.swift
+++ b/Sources/XCResultKit/ActionsInvocationRecord.swift
@@ -33,7 +33,7 @@ public struct ActionsInvocationRecord: XCResultObject {
             archive = xcOptional(element: "archive", from: json)
             actions = xcArray(element: "actions", from: json).ofType(ActionRecord.self)
         } catch {
-            debug("Error parsing ActionsInvocationRecord: \(error.localizedDescription)")
+            logError("Error parsing ActionsInvocationRecord: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStep.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerControlFlowStep.swift
@@ -37,7 +37,7 @@ public struct ActivityLogAnalyzerControlFlowStep: XCResultObject {
             edges = xcArray(element: "edges", from: json)
                 .ofType(ActivityLogAnalyzerControlFlowStepEdge.self)
         } catch {
-            debug("Error parsing ActivityLogAnalyzerControlFlowStep: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogAnalyzerControlFlowStep: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogAnalyzerEventStep.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerEventStep.swift
@@ -36,7 +36,7 @@ public struct ActivityLogAnalyzerEventStep: XCResultObject {
             description = try xcRequired(element: "description", from: json)
             callDepth = try xcRequired(element: "callDepth", from: json)
         } catch {
-            debug("Error parsing ActivityLogAnalyzerEventStep: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogAnalyzerEventStep: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogAnalyzerResultMessage.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerResultMessage.swift
@@ -45,7 +45,7 @@ public struct ActivityLogAnalyzerResultMessage: XCResultObject {
             resultType = xcOptional(element: "resultType", from: json)
             keyEventIndex = try xcRequired(element: "keyEventIndex", from: json)
         } catch {
-            debug("Error parsing ActivityLogAnalyzerResultMessage: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogAnalyzerResultMessage: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogAnalyzerWarningMessage.swift
+++ b/Sources/XCResultKit/ActivityLogAnalyzerWarningMessage.swift
@@ -29,7 +29,7 @@ public struct ActivityLogAnalyzerWarningMessage: XCResultObject {
             annotations = xcArray(element: "annotation", from: json)
                 .ofType(ActivityLogMessageAnnotation.self)
         } catch {
-            debug("Error parsing ActivityLogAnalyzerWarningMessage: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogAnalyzerWarningMessage: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
+++ b/Sources/XCResultKit/ActivityLogCommandInvocationSection.swift
@@ -59,7 +59,7 @@ public struct ActivityLogCommandInvocationSection: XCResultObject {
             emittedOutput = xcOptional(element: "emittedOutput", from: json)
             exitCode = xcOptional(element: "exitCode", from: json)
         } catch {
-            debug("Error parsing ActivityLogCommandInvocationSection: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogCommandInvocationSection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogMajorSection.swift
+++ b/Sources/XCResultKit/ActivityLogMajorSection.swift
@@ -53,7 +53,7 @@ public struct ActivityLogMajorSection: XCResultObject {
 
             subtitle = try xcRequired(element: "subtitle", from: json)
         } catch {
-            debug("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogMessage.swift
+++ b/Sources/XCResultKit/ActivityLogMessage.swift
@@ -35,7 +35,7 @@ public struct ActivityLogMessage: XCResultObject {
             annotations = xcArray(element: "annotation", from: json)
                 .ofType(ActivityLogMessageAnnotation.self)
         } catch {
-            debug("Error parsing ActivityLogMessage: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogMessage: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogMessageAnnotation.swift
+++ b/Sources/XCResultKit/ActivityLogMessageAnnotation.swift
@@ -22,7 +22,7 @@ public struct ActivityLogMessageAnnotation: XCResultObject {
             title = try xcRequired(element: "title", from: json)
             location = xcOptional(element: "location", from: json)
         } catch {
-            debug("Error parsing ActivityLogMessageAnnotation: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogMessageAnnotation: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogSection.swift
+++ b/Sources/XCResultKit/ActivityLogSection.swift
@@ -54,7 +54,7 @@ public struct ActivityLogSection: XCResultObject {
             warningMessage = xcArray(element: "messages", from: json)
                 .ofType(ActivityLogAnalyzerWarningMessage.self)
         } catch {
-            debug("Error parsing ActivityLogSection: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogSection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogTargetBuildSection.swift
+++ b/Sources/XCResultKit/ActivityLogTargetBuildSection.swift
@@ -55,7 +55,7 @@ public struct ActivityLogTargetBuildSection: XCResultObject {
             subtitle = try xcRequired(element: "subtitle", from: json)
             productType = xcOptional(element: "productType", from: json)
         } catch {
-            debug("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogTargetBuildSection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/ActivityLogUnitTestSection.swift
+++ b/Sources/XCResultKit/ActivityLogUnitTestSection.swift
@@ -74,7 +74,7 @@ public struct ActivityLogUnitTestSection: XCResultObject {
             runnablePath = xcOptional(element: "runnablePath", from: json)
             runnableUTI = xcOptional(element: "runnableUTI", from: json)
         } catch {
-            debug("Error parsing ActivityLogUnitTestSection: \(error.localizedDescription)")
+            logError("Error parsing ActivityLogUnitTestSection: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/DocumentLocation.swift
+++ b/Sources/XCResultKit/DocumentLocation.swift
@@ -22,7 +22,7 @@ public struct DocumentLocation: XCResultObject {
             url = try xcRequired(element: "url", from: json)
             concreteTypeName = try xcRequired(element: "concreteTypeName", from: json)
         } catch {
-            debug("Error parsing DocumentLocation: \(error.localizedDescription)")
+            logError("Error parsing DocumentLocation: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/IssueSummary.swift
+++ b/Sources/XCResultKit/IssueSummary.swift
@@ -28,7 +28,7 @@ public struct IssueSummary: XCResultObject {
             producingTarget = xcOptional(element: "producingTarget", from: json)
             documentLocationInCreatingWorkspace = xcOptional(element: "documentLocationInCreatingWorkspace", from: json)
         } catch {
-            debug("Error parsing IssueSummary: \(error.localizedDescription)")
+            logError("Error parsing IssueSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/Logger.swift
+++ b/Sources/XCResultKit/Logger.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Log message only in debug environment
-func debug(_ message: String) {
+func logError(_ message: String) {
     #if DEBUG
         if let data = "\(message)\n".data(using: .utf8) {
             FileHandle.standardError.write(data)

--- a/Sources/XCResultKit/Reference.swift
+++ b/Sources/XCResultKit/Reference.swift
@@ -24,7 +24,7 @@ public struct Reference: XCResultObject {
             id = try xcRequired(element: "id", from: json)
             targetType = xcOptional(element: "targetType", from: json)
         } catch {
-            debug("Error parsing Reference: \(error.localizedDescription)")
+            logError("Error parsing Reference: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/TestFailureIssueSummary.swift
+++ b/Sources/XCResultKit/TestFailureIssueSummary.swift
@@ -27,7 +27,7 @@ public struct TestFailureIssueSummary: XCResultObject {
             producingTarget = xcOptional(element: "producingTarget", from: json)
             documentLocationInCreatingWorkspace = xcOptional(element: "documentLocationInCreatingWorkspace", from: json)
         } catch {
-            debug("Error parsing TestFailureIssueSummary: \(error.localizedDescription)")
+            logError("Error parsing TestFailureIssueSummary: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/TypeDefinition.swift
+++ b/Sources/XCResultKit/TypeDefinition.swift
@@ -19,7 +19,7 @@ public struct TypeDefinition: XCResultObject {
         do {
             name = try xcRequired(element: "name", from: json)
         } catch {
-            debug("Error parsing TypeDefinition: \(error.localizedDescription)")
+            logError("Error parsing TypeDefinition: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/XCResultKit/XCResultBool.swift
+++ b/Sources/XCResultKit/XCResultBool.swift
@@ -12,12 +12,12 @@ extension Bool: XCResultObject {
     public init?(_ json: [String: AnyObject]) {
         // Ensure we have the correct type here
         guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Bool" else {
-            debug("Incorrect type, expecting Bool")
+            logError("Incorrect type, expecting Bool")
             return nil
         }
 
         guard let actualValue = json["_value"] as? NSString else {
-            debug("Unable to get bool value")
+            logError("Unable to get bool value")
             return nil
         }
 

--- a/Sources/XCResultKit/XCResultDate.swift
+++ b/Sources/XCResultKit/XCResultDate.swift
@@ -19,17 +19,17 @@ extension Date: XCResultObject {
     public init?(_ json: [String: AnyObject]) {
         // Ensure we have the correct type here
         guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Date" else {
-            debug("Incorrect type, expecting Date")
+            logError("Incorrect type, expecting Date")
             return nil
         }
 
         guard let actualValue = json["_value"] as? NSString else {
-            debug("Unable to get date value")
+            logError("Unable to get date value")
             return nil
         }
 
         guard let date = Date.isoFormatter.date(from:actualValue as String) else {
-            debug("error parsing date: \(actualValue as String)")
+            logError("error parsing date: \(actualValue as String)")
             return nil
         }
 

--- a/Sources/XCResultKit/XCResultDouble.swift
+++ b/Sources/XCResultKit/XCResultDouble.swift
@@ -12,12 +12,12 @@ extension Double: XCResultObject {
     public init?(_ json: [String: AnyObject]) {
         // Ensure we have the correct type here
         guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Double" else {
-            debug("Incorrect type, expecting Double")
+            logError("Incorrect type, expecting Double")
             return nil
         }
 
         guard let actualValue = json["_value"] as? NSString else {
-            debug("Unable to get double value")
+            logError("Unable to get double value")
             return nil
         }
 

--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -23,19 +23,19 @@ public class XCResultFile {
         
         do {
             guard let data = getOutput.data(using: .utf8) else {
-                debug("Unable to turn string into data, must not be a utf8 string")
+                logError("Unable to turn string into data, must not be a utf8 string")
                 return nil
             }
             
             guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                debug("Expecting top level dictionary but didn't find one")
+                logError("Expecting top level dictionary but didn't find one")
                 return nil
             }
             
             let invocation = ActionsInvocationRecord(rootJSON)
             return invocation
         } catch {
-            debug("Error deserializing JSON: \(error)")
+            logError("Error deserializing JSON: \(error)")
             return nil
         }
     }
@@ -48,19 +48,19 @@ public class XCResultFile {
         
         do {
             guard let data = getOutput.data(using: .utf8) else {
-                debug("Unable to turn string into data, must not be a utf8 string")
+                logError("Unable to turn string into data, must not be a utf8 string")
                 return nil
             }
             
             guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                debug("Expecting top level dictionary but didn't find one")
+                logError("Expecting top level dictionary but didn't find one")
                 return nil
             }
             
             let runSummaries = ActionTestPlanRunSummaries(rootJSON)
             return runSummaries
         } catch {
-            debug("Error deserializing JSON: \(error)")
+            logError("Error deserializing JSON: \(error)")
             return nil
         }
     }
@@ -72,17 +72,17 @@ public class XCResultFile {
 
         do {
             guard let data = getOutput.data(using: .utf8) else {
-                debug("Unable to turn string into data, must not be a utf8 string")
+                logError("Unable to turn string into data, must not be a utf8 string")
                 return nil
             }
             guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                debug("Expecting top level dictionary but didn't find one")
+                logError("Expecting top level dictionary but didn't find one")
                 return nil
             }
 
             return ActivityLogSection(rootJSON)
         } catch {
-            debug("Error deserializing JSON: \(error)")
+            logError("Error deserializing JSON: \(error)")
             return nil
         }
     }
@@ -95,19 +95,19 @@ public class XCResultFile {
         
         do {
             guard let data = getOutput.data(using: .utf8) else {
-                debug("Unable to turn string into data, must not be a utf8 string")
+                logError("Unable to turn string into data, must not be a utf8 string")
                 return nil
             }
             
             guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                debug("Expecting top level dictionary but didn't find one")
+                logError("Expecting top level dictionary but didn't find one")
                 return nil
             }
             
             let summary = ActionTestSummary(rootJSON)
             return summary
         } catch {
-            debug("Error deserializing JSON: \(error)")
+            logError("Error deserializing JSON: \(error)")
             return nil
         }
     }
@@ -119,7 +119,7 @@ public class XCResultFile {
         }
         
         guard let data = getOutput.data(using: .utf8) else {
-            debug("Unable to turn string into data, must not be a utf8 string")
+            logError("Unable to turn string into data, must not be a utf8 string")
             return nil
         }
         return data
@@ -140,14 +140,14 @@ public class XCResultFile {
         
         do {
             guard let data = getOutput.data(using: .utf8) else {
-                debug("Unable to turn string into data, must not be a utf8 string")
+                logError("Unable to turn string into data, must not be a utf8 string")
                 return nil
             }
             
             let decoded = try JSONDecoder().decode(CodeCoverage.self, from: data)
             return decoded
         } catch {
-            debug("Error deserializing JSON: \(error)")
+            logError("Error deserializing JSON: \(error)")
             return nil
         }
     }

--- a/Sources/XCResultKit/XCResultInt.swift
+++ b/Sources/XCResultKit/XCResultInt.swift
@@ -12,12 +12,12 @@ extension Int: XCResultObject {
     public init?(_ json: [String: AnyObject]) {
         // Ensure we have the correct type here
         guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Int" else {
-            debug("Incorrect type, expecting Int")
+            logError("Incorrect type, expecting Int")
             return nil
         }
 
         guard let actualValue = json["_value"] as? NSString else {
-            debug("Unable to get int value")
+            logError("Unable to get int value")
             return nil
         }
 

--- a/Sources/XCResultKit/XCResultString.swift
+++ b/Sources/XCResultKit/XCResultString.swift
@@ -12,12 +12,12 @@ extension String: XCResultObject {
     public init?(_ json: [String: AnyObject]) {
         // Ensure we have the correct type here
         guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "String" else {
-            debug("Incorrect type, expecting String")
+            logError("Incorrect type, expecting String")
             return nil
         }
 
         guard let actualValue = json["_value"] as? NSString else {
-            debug("Unable to get string value")
+            logError("Unable to get string value")
             return nil
         }
 


### PR DESCRIPTION
This PR renames the `debug` method to `logError` to reflect its purpose more accurately.

Closes #9 