### PR TITLE
🐎 Integrate stampede for pr checks and release notes

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -1,0 +1,16 @@
+pullrequests:
+  tasks:
+    - id: pr-standards
+      config:
+        prMilestoneCheck: true
+        prBodyCheck: true
+pullrequestedit:
+  tasks:
+    - id: pr-standards
+      config:
+        prMilestoneCheck: true
+        prBodyCheck: true
+releases:
+  published:
+    tasks:
+      - id: release-notes


### PR DESCRIPTION
This PR integrates the stampede CI system to perform PR standards checks and release notes. For PRs, we just want to make sure a Milestone is selected and some kind of body exists. We might add some things later, but this will get us the basics. Adding in Unit testing and swiftlint will come soon in separate PRs, I just need to do some setup before enabling that.