### PR TITLE
waiting until task actually completes before returning from xcrun method

### DIFF
--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -163,7 +163,9 @@ public class XCResultFile {
         
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let output: String? = String(data: data, encoding: String.Encoding.utf8)
-        
+
+        task.waitUntilExit()
+
         return output
     }
 }


### PR DESCRIPTION
Hi!
I've been using https://github.com/TitouanVanBelle/XCTestHTMLReport, with includes `XCResultKit` via SwiftPM. It uses `XCResultKit`, especially `XCResultFile` to parse and process data from .xcresult files. `XCTestHTMLReport` uses a loop to traverse all the files from the .xcresult bundle, which in turn creates a lot of  `XCResultFile` objects. `XCResultFile` uses `Process` class to call `xcrun` command and a `Pipe` object to fetch output. The problem arises when I try to parse a lot of .xcresult files - file descriptors obtained by `Pipe` are not being closed, since current autorelease pool has no chance to release all the `Pipe` and `Process` classes, which results in errors like `*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Failed to set posix_spawn_file_actions for fd 10240 at index 1 with errno 9'`
(There is also an old radar about this problem - https://openradar.appspot.com/10257191)
The fix is to call `waitUntilExit()` method to wait until task actually completes and let it free all the aquired resources