### PR TITLE
add autoreleasepool for fixing crash in NSTask

### DIFF
--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -153,19 +153,21 @@ public class XCResultFile {
     }
     
     private func xcrun(_ arguments: [String]) -> String? {
-        let task = Process()
-        task.launchPath = "/usr/bin/xcrun"
-        task.arguments = arguments
-        
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.launch()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output: String? = String(data: data, encoding: String.Encoding.utf8)
+        autoreleasepool {
+            let task = Process()
+            task.launchPath = "/usr/bin/xcrun"
+            task.arguments = arguments
+            
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.launch()
+            
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output: String? = String(data: data, encoding: String.Encoding.utf8)
 
-        task.waitUntilExit()
+            task.waitUntilExit()
 
-        return output
+            return output
+        }
     }
 }


### PR DESCRIPTION
Hi!

I'm using your package for creating test reports, but I've got a crash, when tried to create a report for more than 100 tests. 
![image](https://user-images.githubusercontent.com/37310530/71478139-18890c80-27ff-11ea-86f6-bb813e27efa3.png)

And I found out that if this code is calling many times, I should close the pipe. First way to resolve this issue is adding `<closeFile>` to the `<fileHandleForReading>`, but putting this code in the autoreleasepool statement is correct too
https://stackoverflow.com/questions/25370280/getting-a-crash-in-nstask
