### PR TITLE
Provide public initializers for CodeCoverage models

### DIFF
--- a/Sources/XCResultKit/CodeCoverage.swift
+++ b/Sources/XCResultKit/CodeCoverage.swift
@@ -34,6 +34,13 @@ public struct CodeCoverage: Codable {
         }
     }
     
+    public init(coveredLines: Int, lineCoverage: Double, executableLines: Int, targets: [CodeCoverageTarget]){
+        self.coveredLines = coveredLines
+        self.lineCoverage = lineCoverage
+        self.executableLines = executableLines
+        self.targets = targets
+    }
+    
     public func filesCoveredAdequately() -> [CodeCoverageFile] {
         var files: [CodeCoverageFile] = []
         for target in targets {
@@ -74,6 +81,15 @@ public struct CodeCoverageTarget: Codable {
     public let executableLines: Int
     public let buildProductPath: String
     public let files: [CodeCoverageFile]
+
+    public init(name: String,  buildProductPath: String, files: [CodeCoverageFile]){
+        self.name = name
+        self.coveredLines = coveredLines
+        self.lineCoverage = lineCoverage
+        self.executableLines = executableLines
+        self.buildProductPath = buildProductPath
+        self.files = files
+    }
 }
 
 public struct CodeCoverageFile: Codable {
@@ -82,4 +98,12 @@ public struct CodeCoverageFile: Codable {
     public let path: String
     public let name: String
     public let executableLines: Int
+    
+    public init(coveredLines: Int, lineCoverage: Double,  path: Stringname: String, executableLines: Int){
+        self.name = name
+        self.coveredLines = coveredLines
+        self.lineCoverage = lineCoverage
+        self.executableLines = executableLines
+        self.path = path
+    }
 }

--- a/Sources/XCResultKit/CodeCoverage.swift
+++ b/Sources/XCResultKit/CodeCoverage.swift
@@ -35,7 +35,7 @@ public struct CodeCoverage: Codable {
         }
     }
     
-    public init(targets: [CodeCoverageTarget]){
+    public init(targets: [CodeCoverageTarget]) {
         coveredLines = targets.reduce(0) {$0 + $1.coveredLines}
         executableLines = targets.reduce(0) {$0 + $1.executableLines}
         lineCoverage = Double(coveredLines) / Double(executableLines)
@@ -83,7 +83,7 @@ public struct CodeCoverageTarget: Codable {
     public let buildProductPath: String
     public let files: [CodeCoverageFile]
 
-    public init(name: String,  buildProductPath: String, files: [CodeCoverageFile]){
+    public init(name: String, buildProductPath: String, files: [CodeCoverageFile]) {
         self.name = name
         self.files = files
         self.buildProductPath = buildProductPath
@@ -106,7 +106,7 @@ public struct CodeCoverageFile: Codable {
     public let name: String
     public let executableLines: Int
     
-    public init(coveredLines: Int, lineCoverage: Double,  path: String, name: String, executableLines: Int){
+    public init(coveredLines: Int, lineCoverage: Double, path: String, name: String, executableLines: Int) {
         self.name = name
         self.coveredLines = coveredLines
         self.lineCoverage = lineCoverage

--- a/Sources/XCResultKit/CodeCoverage.swift
+++ b/Sources/XCResultKit/CodeCoverage.swift
@@ -20,12 +20,13 @@ public struct CodeCoverage: Codable {
         targets = []
     }
     
-    public init(target: String, files: [CodeCoverageFile]) {
+    public init(target: String, files: [CodeCoverageFile]) {        
         if files.count > 0 {
-            coveredLines = files.reduce(0) {$0 + $1.coveredLines}
-            executableLines = files.reduce(0) {$0 + $1.executableLines}
-            lineCoverage = Double(coveredLines) / Double(executableLines)
-            targets = [CodeCoverageTarget(coveredLines: coveredLines, lineCoverage: lineCoverage, name: target, executableLines: executableLines, buildProductPath: "", files: files)]
+            let target = CodeCoverageTarget(name: target, buildProductPath: "", files: files)
+            coveredLines = target.coveredLines
+            lineCoverage = target.lineCoverage
+            executableLines = target.executableLines
+            targets = [target]
         } else {
             coveredLines = 0
             lineCoverage = 0.0
@@ -34,10 +35,10 @@ public struct CodeCoverage: Codable {
         }
     }
     
-    public init(coveredLines: Int, lineCoverage: Double, executableLines: Int, targets: [CodeCoverageTarget]){
-        self.coveredLines = coveredLines
-        self.lineCoverage = lineCoverage
-        self.executableLines = executableLines
+    public init(targets: [CodeCoverageTarget]){
+        coveredLines = targets.reduce(0) {$0 + $1.coveredLines}
+        executableLines = targets.reduce(0) {$0 + $1.executableLines}
+        lineCoverage = Double(coveredLines) / Double(executableLines)
         self.targets = targets
     }
     
@@ -84,11 +85,17 @@ public struct CodeCoverageTarget: Codable {
 
     public init(name: String,  buildProductPath: String, files: [CodeCoverageFile]){
         self.name = name
-        self.coveredLines = coveredLines
-        self.lineCoverage = lineCoverage
-        self.executableLines = executableLines
-        self.buildProductPath = buildProductPath
         self.files = files
+        self.buildProductPath = buildProductPath
+        if files.count > 0 {
+            coveredLines = files.reduce(0) {$0 + $1.coveredLines}
+            executableLines = files.reduce(0) {$0 + $1.executableLines}
+            lineCoverage = Double(coveredLines) / Double(executableLines)
+        } else {
+            coveredLines = 0
+            lineCoverage = 0.0
+            executableLines = 0
+        }
     }
 }
 
@@ -99,7 +106,7 @@ public struct CodeCoverageFile: Codable {
     public let name: String
     public let executableLines: Int
     
-    public init(coveredLines: Int, lineCoverage: Double,  path: Stringname: String, executableLines: Int){
+    public init(coveredLines: Int, lineCoverage: Double,  path: String, name: String, executableLines: Int){
         self.name = name
         self.coveredLines = coveredLines
         self.lineCoverage = lineCoverage

--- a/Sources/XCResultKit/CodeCoverage.swift
+++ b/Sources/XCResultKit/CodeCoverage.swift
@@ -20,7 +20,7 @@ public struct CodeCoverage: Codable {
         targets = []
     }
     
-    public init(target: String, files: [CodeCoverageFile]) {        
+    public init(target: String, files: [CodeCoverageFile]) {
         if files.count > 0 {
             let target = CodeCoverageTarget(name: target, buildProductPath: "", files: files)
             coveredLines = target.coveredLines

--- a/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
+++ b/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
@@ -79,4 +79,15 @@ final class CodeCoverageTests: XCTestCase {
         }
     }
     """
+    
+    func testInitializers() {
+        let codeCoverageFile = CodeCoverageFile(coveredLines: 5, lineCoverage: 0.5, path: "fooPath", name: "bar.swift", executableLines: 10)
+        XCTAssertEqual(codeCoverageFile.coveredLines, 5)
+        XCTAssertEqual(codeCoverageFile.lineCoverage, 0.5)
+        XCTAssertEqual(codeCoverageFile.path, "fooPath")
+        XCTAssertEqual(codeCoverageFile.name, "bar.swift")
+        XCTAssertEqual(codeCoverageFile.executableLines, 10)
+        let codeCoverageFile2 = CodeCoverageFile(coveredLines: 3, lineCoverage: 0.5, path: "fooPath2", name: "bar2.swift", executableLines: 6)
+        
+    }
 }

--- a/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
+++ b/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
@@ -89,5 +89,18 @@ final class CodeCoverageTests: XCTestCase {
         XCTAssertEqual(codeCoverageFile.executableLines, 10)
         let codeCoverageFile2 = CodeCoverageFile(coveredLines: 3, lineCoverage: 0.5, path: "fooPath2", name: "bar2.swift", executableLines: 6)
         
+        let codeCoverageTarget = CodeCoverageTarget(name: "MyCode.framework", buildProductPath: "buildPath", files: [codeCoverageFile, codeCoverageFile2])
+        XCTAssertEqual(codeCoverageTarget.name, "MyCode.framework")
+        XCTAssertEqual(codeCoverageTarget.buildProductPath, "buildPath")
+        XCTAssertEqual(codeCoverageTarget.coveredLines, 8)
+        XCTAssertEqual(codeCoverageTarget.executableLines, 16)
+        XCTAssertEqual(codeCoverageTarget.lineCoverage, 0.5)
+        
+        let codeCoverageFile3 = CodeCoverageFile(coveredLines: 4, lineCoverage: 0.25, path: "fooPath3", name: "bar3.swift", executableLines: 16)
+        let codeCoverageTarget2 = CodeCoverageTarget(name: "MyOtherCode.framework", buildProductPath: "buildPath", files: [codeCoverageFile3])
+        let codeCoverage = CodeCoverage(targets: [codeCoverageTarget, codeCoverageTarget2])
+        XCTAssertEqual(codeCoverage.coveredLines, 12)
+        XCTAssertEqual(codeCoverage.executableLines, 32)
+        XCTAssertEqual(codeCoverage.lineCoverage, 0.375)
     }
 }


### PR DESCRIPTION
Swift creates default struct initializers as internal, which means they can't be used outside of a package.

I'd like to be able to use XCResultKit to allow for various post processing of CodeCoverage in another package (probably someday open sourced).  To make this clean I need to be able to instantiate the models without using the Codable initializers.

This PR simply exposes some public initializers for these model classes.  I did some minor refactoring to keep it clean.

Unit test included to ensure the initializers work.