### PR TITLE
♻️ Optimized handles for exportPayload method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,14 +44,6 @@ playground.xcworkspace
 # Package.resolved
 .build/
 
-# CocoaPods
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# Pods/
-
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.

--- a/Sources/XCResultKit/ActionDeviceRecord.swift
+++ b/Sources/XCResultKit/ActionDeviceRecord.swift
@@ -48,7 +48,6 @@ public struct ActionDeviceRecord: XCResultObject, Encodable {
     public let logicalCPUCoresPerPackage: Int?
     public let platformRecord: ActionPlatformRecord
     
-
     public init?(_ json: [String: AnyObject]) {
         do {
             name = try xcRequired(element: "name", from: json)


### PR DESCRIPTION
This PR removes some file handles created when the `exportPayload` method is called. In this case we don't care about the output of the `xcrun` command so there is no need to capture it. This might help address some issues related to many handles getting allocated when exporting lots of attachments.

closes #23 