### PR TITLE
Fix export payload

### DIFF
--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -143,6 +143,8 @@ public class XCResultFile {
                 task.launch()
                 
                 resultData = pipe.fileHandleForReading.readDataToEndOfFile()
+            } else {
+                task.launch()
             }
             
             task.waitUntilExit()


### PR DESCRIPTION
- 0.5.6 release broke exportPayload.  The task wasn't being launched.

In the project I'm working on I've added some xcresult bundles as fixture files so I can write unit/integration tests that really work on xcresult bundles.  Might be something to consider.