### PR TITLE
Implement testsSkippedCount which is new in Xcode 11.4

### DIFF
--- a/Sources/XCResultKit/ResultMetrics.swift
+++ b/Sources/XCResultKit/ResultMetrics.swift
@@ -21,6 +21,7 @@ public struct ResultMetrics: XCResultObject {
     public let testsCount: Int?
     public let testsFailedCount: Int?
     public let warningCount: Int?
+    public let testsSkippedCount: Int?
     
     public init?(_ json: [String: AnyObject]) {    
         analyzerWarningCount = xcOptional(element: "analyzerWarningCount", from: json)
@@ -28,5 +29,6 @@ public struct ResultMetrics: XCResultObject {
         testsCount = xcOptional(element: "testsCount", from: json)
         testsFailedCount = xcOptional(element: "testsFailedCount", from: json)
         warningCount = xcOptional(element: "warningCount", from: json)
+        testsSkippedCount = xcOptional(element: "testsSkippedCount", from: json)
     }
 }

--- a/Tests/XCResultKitTests/ResultMetricsTests.swift
+++ b/Tests/XCResultKitTests/ResultMetricsTests.swift
@@ -12,15 +12,23 @@ import XCTest
 
 final class ResultMetricsTests: XCTestCase {
     
-    func testCanParseCorrectlyFormattedJSON() {
-        
-        let parsed = ResultMetrics(parse(resultMetricsJson))
-        XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed?.testsCount, 1)
+    func testCanParseCorrectlyFormattedJSON() throws {
+        let parsed = try XCTUnwrap(ResultMetrics(parse(resultMetricsJson)))
+        XCTAssertEqual(parsed.testsCount, 1)
+        XCTAssertEqual(parsed.testsFailedCount, nil)
+        XCTAssertEqual(parsed.testsSkippedCount, nil)
+    }
+
+    func testCanParseCorrectlyFormattedJSON2() throws {
+        let parsed = try XCTUnwrap(ResultMetrics(parse(resultMetricsJson2)))
+        XCTAssertEqual(parsed.testsCount, 10)
+        XCTAssertEqual(parsed.testsFailedCount, 4)
+        XCTAssertEqual(parsed.testsSkippedCount, 1)
     }
     
     static var allTests = [
         ("testCanParseCorrectlyFormattedJSON", testCanParseCorrectlyFormattedJSON),
+        ("testCanParseCorrectlyFormattedJSON2", testCanParseCorrectlyFormattedJSON2),
         ]
     
     private func parse(_ jsonData: String) -> [String: AnyObject] {
@@ -45,6 +53,32 @@ final class ResultMetricsTests: XCTestCase {
             "_name" : "ResultMetrics"
         },
         "testsCount" : {
+            "_type" : {
+                "_name" : "Int"
+            },
+            "_value" : "1"
+        }
+    }
+    """
+
+    let resultMetricsJson2 = """
+    {
+        "_type" : {
+            "_name" : "ResultMetrics"
+        },
+        "testsCount" : {
+            "_type" : {
+                "_name" : "Int"
+            },
+            "_value" : "10"
+        },
+        "testsFailedCount" : {
+            "_type" : {
+                "_name" : "Int"
+            },
+            "_value" : "4"
+        },
+        "testsSkippedCount" : {
             "_type" : {
                 "_name" : "Int"
             },


### PR DESCRIPTION
Hello, In Xcode11.4 new apis were added: XCTSkipIf() and XCTSkipInless() 

```swift
func testResultFile() throws {
        let condition = true
        try XCTSkipIf(condition, "Test was skipped because of ...")
        ...
}
```

When a test like above is skipped `ResultMetrics` results will contain `testsSkippedCount`. This PR reads that value so clients will be able to access this information.

Also result `ActionTestMetadata` `testStatus` will be "Skipped" but since this is declared as String no changes are required. It already works :)



