### PR TITLE
✨ Added support for parsing LogStoreManifest.plist files

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -15,6 +15,7 @@ pullrequests:
     - id: swift-package-test
       config:
         projectFolder: .
+        xcodeVersion: Xcode.app
 # tasks that run when a PR is edited
 pullrequestedit:
   tasks:

--- a/.swiftpm/xcode/xcshareddata/xcschemes/XCResultKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/XCResultKit.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1230"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCResultKit"
+               BuildableName = "XCResultKit"
+               BlueprintName = "XCResultKit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCResultKitTests"
+               BuildableName = "XCResultKitTests"
+               BlueprintName = "XCResultKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCResultKitTests"
+               BuildableName = "XCResultKitTests"
+               BlueprintName = "XCResultKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "XCResultKit"
+            BuildableName = "XCResultKit"
+            BlueprintName = "XCResultKit"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/XCResultKit/LogStoreExecution.swift
+++ b/Sources/XCResultKit/LogStoreExecution.swift
@@ -1,0 +1,59 @@
+//
+//  File.swift
+//  
+//
+//  Created by David House on 1/24/21.
+//
+
+import Foundation
+
+/// LogStoreExecution represents the details for a single test execution from Xcode
+struct LogStoreExecution {
+    let auxiliaryLogUniqueIdentifier: String
+    let auxiliaryObservable: [String: String]
+    let className: String
+    let documentTypeString: String
+    let domainType: String
+    let fileName: String
+    let hasAuxiliaryLog: Bool
+    let hasCoverageData: Bool
+    let hasPrimaryLog: Bool
+    let primaryObservable: [String: String]
+    let schemeIdentifierContainerName: String
+    let schemeIdentifierSchemeName: String
+    let schemeIdentifierSharedScheme: Int
+    let signature: String
+    let timeStartedRecording: Double
+    let timeStoppedRecording: Double
+    let title: String
+    let uniqueIdentifier: String
+    
+    init(_ details: [String: Any]) {
+        auxiliaryLogUniqueIdentifier = plistValue("auxiliaryLogUniqueIdentifier", from: details, defaultValue: "")
+        auxiliaryObservable = plistValue("auxiliaryObservable", from: details, defaultValue: [:])
+        className = plistValue("className", from: details, defaultValue: "")
+        documentTypeString = plistValue("documentTypeString", from: details, defaultValue: "")
+        domainType = plistValue("domainType", from: details, defaultValue: "")
+        fileName = plistValue("fileName", from: details, defaultValue: "")
+        hasAuxiliaryLog = plistValue("hasAuxiliaryLog", from: details, defaultValue: false)
+        hasCoverageData = plistValue("hasCoverageData", from: details, defaultValue: false)
+        hasPrimaryLog = plistValue("hasPrimaryLog", from: details, defaultValue: false)
+        primaryObservable = plistValue("primaryObservable", from: details, defaultValue: [:])
+        schemeIdentifierContainerName = plistValue("schemeIdentifierContainerName", from: details, defaultValue: "")
+        schemeIdentifierSchemeName = plistValue("schemeIdentifierSchemeName", from: details, defaultValue: "")
+        schemeIdentifierSharedScheme = plistValue("schemeIdentifierSharedScheme", from: details, defaultValue: 0)
+        signature = plistValue("signature", from: details, defaultValue: "")
+        timeStartedRecording = plistValue("timeStartedRecording", from: details, defaultValue: 0.0)
+        timeStoppedRecording = plistValue("timeStoppedRecording", from: details, defaultValue: 0.0)
+        title = plistValue("title", from: details, defaultValue: "")
+        uniqueIdentifier = plistValue("uniqueIdentifier", from: details, defaultValue: "")
+    }
+}
+
+private func plistValue<T>(_ key: String, from details: [String: Any], defaultValue: T) -> T {
+    if let value = details[key] as? T {
+        return value
+    } else {
+        return defaultValue
+    }
+}

--- a/Sources/XCResultKit/LogStoreManifest.swift
+++ b/Sources/XCResultKit/LogStoreManifest.swift
@@ -1,0 +1,52 @@
+//
+//  File.swift
+//  
+//
+//  Created by David House on 1/24/21.
+//
+
+import Foundation
+
+enum LogStoreManifestError: Error {
+    case invalidVersion
+}
+
+/// Load & parse the LogStoreManifest.plist file that can be found in the Derived Data sub folder
+/// Logs/Test. This file contains information about all the test executions captured by Xcode
+/// for the project.
+class LogStoreManifest {
+    
+    var executions: [LogStoreExecution] = []
+    
+    /// Initialize with the path to the LogStoreManifest.plist
+    init(url: URL) throws {
+        if let data = try? Data(contentsOf: url),
+           let plist = try PropertyListSerialization.propertyList(from: data, options: .mutableContainers, format: nil) as? [String: Any] {
+            try parseExecutions(from: plist)
+        }
+    }
+    
+    /// Initialize with the Data from a LogStoreManifest.plist file
+    init(data: Data) throws {
+        if let plist = try PropertyListSerialization.propertyList(from: data, options: .mutableContainers, format: nil) as? [String: Any] {
+         try parseExecutions(from: plist)
+        }
+    }
+    
+    private func parseExecutions(from plist: [String: Any]) throws {
+        
+        guard let fileVersion = plist["logFormatVersion"] as? Int, fileVersion == 10 else {
+            throw LogStoreManifestError.invalidVersion
+        }
+        
+        guard let logs = plist["logs"] as? [String: Any] else {
+            return
+        }
+        
+        for (_, value) in logs {
+            if let executionDetails = value as? [String: Any] {
+                executions.append(LogStoreExecution(executionDetails))
+            }
+        }
+    }
+}

--- a/TestResources/LogStoreManifest.plist
+++ b/TestResources/LogStoreManifest.plist
@@ -1,0 +1,686 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>logFormatVersion</key>
+	<integer>10</integer>
+	<key>logs</key>
+	<dict>
+		<key>0EBE163A-644A-419D-92D8-957B0B912018</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>7665227E-8402-402D-9E86-2394DFAFD202</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-48-49--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>E</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192529.196661</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>0EBE163A-644A-419D-92D8-957B0B912018</string>
+		</dict>
+		<key>2119E707-B8CA-4075-8F92-D86B16D0563F</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>778E5D5B-CAE4-4126-A0F6-9FB1B34B1B71</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-35-03--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633191703.34843004</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>2119E707-B8CA-4075-8F92-D86B16D0563F</string>
+		</dict>
+		<key>22FD0AE5-62A4-4A47-AF8D-4E5658E969EE</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>08B016C4-14A8-46B3-BF78-00D929464EE0</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-42-07--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192127.53312004</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>22FD0AE5-62A4-4A47-AF8D-4E5658E969EE</string>
+		</dict>
+		<key>24D0D735-09C3-45CA-B089-0927F183D967</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>90EB7FFA-C66D-4E04-B2B3-D4CF09BB428B</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-37-55--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633191875.96857798</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>24D0D735-09C3-45CA-B089-0927F183D967</string>
+		</dict>
+		<key>28C8C405-24B6-4781-917A-279F72F5985E</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>EFD21368-A7AB-4D3C-BEAF-A245925C3C5E</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_08-58-18--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633189498.36201704</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>28C8C405-24B6-4781-917A-279F72F5985E</string>
+		</dict>
+		<key>5FE5C100-F747-48E0-83E2-115DB19D4D29</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>9D1CF737-211C-4B35-B805-3ABAC956F2F1</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-42-49--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192169.95776403</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>5FE5C100-F747-48E0-83E2-115DB19D4D29</string>
+		</dict>
+		<key>63D5E104-A278-4FF7-B30C-3C8AAF6F44E9</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>04613FA4-DFF1-4AE0-B811-B5C0DC40CAC5</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_08-59-30--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633189570.24985099</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>63D5E104-A278-4FF7-B30C-3C8AAF6F44E9</string>
+		</dict>
+		<key>9087CBE5-7CEC-46DE-B535-477FD093A219</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>52B074E2-47DD-48C6-A632-1B2AD7F5A896</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-46-42--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192402.80760896</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>9087CBE5-7CEC-46DE-B535-477FD093A219</string>
+		</dict>
+		<key>AC1CDB19-A7DA-4959-92D3-93D9130980AA</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>09DE1848-8A6D-4A73-9066-80A6037E9BD1</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_08-48-37--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633188917.36011505</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>AC1CDB19-A7DA-4959-92D3-93D9130980AA</string>
+		</dict>
+		<key>BC5A348D-DDFD-4011-8A24-7D7566E78E6F</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>A65F7035-E3A3-4847-A994-C384390EE08E</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-49-39--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192579.74760401</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>BC5A348D-DDFD-4011-8A24-7D7566E78E6F</string>
+		</dict>
+		<key>D6BFFC69-2D6E-4C2B-9150-9B934A0159A5</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>1453EF49-750E-4E5B-8578-C4D66642DD32</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_08-55-50--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633189350.38487005</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>D6BFFC69-2D6E-4C2B-9150-9B934A0159A5</string>
+		</dict>
+		<key>E4DF01C2-2AE6-4B34-B12A-6D554EA61B1F</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>03E29B41-C028-4357-B036-7A8A9F0C194F</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-00-11--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633189611.94487405</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>E4DF01C2-2AE6-4B34-B12A-6D554EA61B1F</string>
+		</dict>
+		<key>E861C24C-44B5-4F59-A737-C61965EBA0DF</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>A252EE06-B7A1-4E3C-8AB6-A21B4155AD15</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-46-00--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633192360.02053297</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>E861C24C-44B5-4F59-A737-C61965EBA0DF</string>
+		</dict>
+		<key>FC5B9F9E-0E8D-415E-907E-FEECB7A68DDB</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>54CB3D63-5407-4046-A2E1-453654FD5ABC</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-32-47--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633191567.25579</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>FC5B9F9E-0E8D-415E-907E-FEECB7A68DDB</string>
+		</dict>
+		<key>FEB1FAF4-8A3F-4BE7-8C70-22DDBF1CD1A3</key>
+		<dict>
+			<key>auxiliaryLogUniqueIdentifier</key>
+			<string>C1B99201-FD4B-4084-A351-A7356212AEE3</string>
+			<key>auxiliaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>W</string>
+			</dict>
+			<key>className</key>
+			<string>IDESchemeActionsInvocationRecord</string>
+			<key>documentTypeString</key>
+			<string>&lt;nil&gt;</string>
+			<key>domainType</key>
+			<string>com.apple.dt.unit.cocoaUnitTest</string>
+			<key>fileName</key>
+			<string>Test-Copy of Stampede-2021.01.24_09-23-41--0500.xcresult</string>
+			<key>hasAuxiliaryLog</key>
+			<true/>
+			<key>hasCoverageData</key>
+			<true/>
+			<key>hasPrimaryLog</key>
+			<true/>
+			<key>primaryObservable</key>
+			<dict>
+				<key>highLevelStatus</key>
+				<string>T</string>
+			</dict>
+			<key>schemeIdentifier-containerName</key>
+			<string>Stampede project</string>
+			<key>schemeIdentifier-schemeName</key>
+			<string>Copy of Stampede</string>
+			<key>schemeIdentifier-sharedScheme</key>
+			<integer>0</integer>
+			<key>signature</key>
+			<string>Test Copy of Stampede</string>
+			<key>timeStartedRecording</key>
+			<real>633191021.70431495</real>
+			<key>timeStoppedRecording</key>
+			<real>0.0</real>
+			<key>title</key>
+			<string>Test Copy of Stampede</string>
+			<key>uniqueIdentifier</key>
+			<string>FEB1FAF4-8A3F-4BE7-8C70-22DDBF1CD1A3</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tests/XCResultKitTests/LogStoreManifestTests.swift
+++ b/Tests/XCResultKitTests/LogStoreManifestTests.swift
@@ -1,0 +1,95 @@
+//
+//  File.swift
+//  
+//
+//  Created by David House on 1/24/21.
+//
+
+import Foundation
+
+import XCTest
+@testable import XCResultKit
+
+final class LogStoreManifestTests: XCTestCase {
+    
+    func testCanParseFromFile() throws {
+        guard let data = testFile.data(using: .utf8) else {
+            XCTFail("Error turning string into data, must not be a utf8 string")
+            return
+        }
+
+        let manifest = try LogStoreManifest(data: data)
+        XCTAssertEqual(manifest.executions.count, 1)
+        XCTAssertEqual(manifest.executions[0].fileName, "Test-Copy of Stampede-2021.01.24_09-48-49--0500.xcresult")
+    }
+        
+    let testFile = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>logFormatVersion</key>
+        <integer>10</integer>
+        <key>logs</key>
+        <dict>
+            <key>0EBE163A-644A-419D-92D8-957B0B912018</key>
+            <dict>
+                <key>auxiliaryLogUniqueIdentifier</key>
+                <string>7665227E-8402-402D-9E86-2394DFAFD202</string>
+                <key>auxiliaryObservable</key>
+                <dict>
+                    <key>highLevelStatus</key>
+                    <string>W</string>
+                </dict>
+                <key>className</key>
+                <string>IDESchemeActionsInvocationRecord</string>
+                <key>documentTypeString</key>
+                <string>&lt;nil&gt;</string>
+                <key>domainType</key>
+                <string>com.apple.dt.unit.cocoaUnitTest</string>
+                <key>fileName</key>
+                <string>Test-Copy of Stampede-2021.01.24_09-48-49--0500.xcresult</string>
+                <key>hasAuxiliaryLog</key>
+                <true/>
+                <key>hasCoverageData</key>
+                <true/>
+                <key>hasPrimaryLog</key>
+                <true/>
+                <key>primaryObservable</key>
+                <dict>
+                    <key>highLevelStatus</key>
+                    <string>E</string>
+                </dict>
+                <key>schemeIdentifier-containerName</key>
+                <string>Stampede project</string>
+                <key>schemeIdentifier-schemeName</key>
+                <string>Copy of Stampede</string>
+                <key>schemeIdentifier-sharedScheme</key>
+                <integer>0</integer>
+                <key>signature</key>
+                <string>Test Copy of Stampede</string>
+                <key>timeStartedRecording</key>
+                <real>633192529.196661</real>
+                <key>timeStoppedRecording</key>
+                <real>0.0</real>
+                <key>title</key>
+                <string>Test Copy of Stampede</string>
+                <key>uniqueIdentifier</key>
+                <string>0EBE163A-644A-419D-92D8-957B0B912018</string>
+            </dict>
+        </dict>
+    </dict>
+    </plist>
+    """
+    
+    let testFilePreviousVersion = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+        <key>logFormatVersion</key>
+        <integer>9</integer>
+    </dict>
+    </plist>
+    """
+}


### PR DESCRIPTION
This PR adds support for parsing `LogStoreManifest.plist` files. You will find one of these in a projects derived data folder under Logs/Test. This file is where Xcode keeps the list of test executions. Previously this library only supported parsing `xcresult` files, but it was up to you to figure out which one to use. One of my primary use cases for this library was for CI where there is usually only a single xcresult file. But if you want to use this library for other cases such as on a developers machine, you need to look at the `LogStoreManifest.plist` file to see what is available in the Logs/Test folder.

You can instantiate the `LogStoreManifest` class by creating a URL that matches the location of the plist file and then passing that to the initializer:

`let manifest = LogStoreManifest(url: theURL)`

Once instantiated, you then have access to the test executions using the `.executions` property.

closes #32 