### PR TITLE
✨ Added functions array to code coverage files

### DIFF
--- a/Sources/XCResultKit/CodeCoverage.swift
+++ b/Sources/XCResultKit/CodeCoverage.swift
@@ -105,12 +105,23 @@ public struct CodeCoverageFile: Codable {
     public let path: String
     public let name: String
     public let executableLines: Int
+    public let functions: [CodeCoverageFileFunction]
     
-    public init(coveredLines: Int, lineCoverage: Double, path: String, name: String, executableLines: Int) {
+    public init(coveredLines: Int, lineCoverage: Double, path: String, name: String, executableLines: Int, functions: [CodeCoverageFileFunction]) {
         self.name = name
         self.coveredLines = coveredLines
         self.lineCoverage = lineCoverage
         self.executableLines = executableLines
         self.path = path
+        self.functions = functions
     }
+}
+
+public struct CodeCoverageFileFunction: Codable {
+    public let coveredLines: Int
+    public let lineCoverage: Double
+    public let lineNumber: Int
+    public let name: String
+    public let executableLines: Int
+    public let executionCount: Int
 }

--- a/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
+++ b/Tests/XCResultKitTests/CodeCoverageInfoTests.swift
@@ -81,13 +81,13 @@ final class CodeCoverageTests: XCTestCase {
     """
     
     func testInitializers() {
-        let codeCoverageFile = CodeCoverageFile(coveredLines: 5, lineCoverage: 0.5, path: "fooPath", name: "bar.swift", executableLines: 10)
+        let codeCoverageFile = CodeCoverageFile(coveredLines: 5, lineCoverage: 0.5, path: "fooPath", name: "bar.swift", executableLines: 10, functions: [])
         XCTAssertEqual(codeCoverageFile.coveredLines, 5)
         XCTAssertEqual(codeCoverageFile.lineCoverage, 0.5)
         XCTAssertEqual(codeCoverageFile.path, "fooPath")
         XCTAssertEqual(codeCoverageFile.name, "bar.swift")
         XCTAssertEqual(codeCoverageFile.executableLines, 10)
-        let codeCoverageFile2 = CodeCoverageFile(coveredLines: 3, lineCoverage: 0.5, path: "fooPath2", name: "bar2.swift", executableLines: 6)
+        let codeCoverageFile2 = CodeCoverageFile(coveredLines: 3, lineCoverage: 0.5, path: "fooPath2", name: "bar2.swift", executableLines: 6, functions: [])
         
         let codeCoverageTarget = CodeCoverageTarget(name: "MyCode.framework", buildProductPath: "buildPath", files: [codeCoverageFile, codeCoverageFile2])
         XCTAssertEqual(codeCoverageTarget.name, "MyCode.framework")
@@ -96,7 +96,7 @@ final class CodeCoverageTests: XCTestCase {
         XCTAssertEqual(codeCoverageTarget.executableLines, 16)
         XCTAssertEqual(codeCoverageTarget.lineCoverage, 0.5)
         
-        let codeCoverageFile3 = CodeCoverageFile(coveredLines: 4, lineCoverage: 0.25, path: "fooPath3", name: "bar3.swift", executableLines: 16)
+        let codeCoverageFile3 = CodeCoverageFile(coveredLines: 4, lineCoverage: 0.25, path: "fooPath3", name: "bar3.swift", executableLines: 16, functions: [])
         let codeCoverageTarget2 = CodeCoverageTarget(name: "MyOtherCode.framework", buildProductPath: "buildPath", files: [codeCoverageFile3])
         let codeCoverage = CodeCoverage(targets: [codeCoverageTarget, codeCoverageTarget2])
         XCTAssertEqual(codeCoverage.coveredLines, 12)


### PR DESCRIPTION
This PR adds in the `functions` array to the `CodeCoverageFile` class. This array lists all the functions in that class that the code coverage tool `xccov` has reported. You can get the name of the function, number of times it was executed and more. You can use this info to build more detailed reports on the code coverage for an individual class.

closes #34 
