### PR TITLE
Allow action summary group duration to be nil

### DIFF
--- a/Sources/XCResultKit/ActionTestSummaryGroup.swift
+++ b/Sources/XCResultKit/ActionTestSummaryGroup.swift
@@ -24,7 +24,7 @@ public struct ActionTestSummaryGroup: XCResultObject {
         do {
             name = try xcRequired(element: "name", from: json)
             identifier = try xcRequired(element: "identifier", from: json)
-            duration = try xcRequired(element: "duration", from: json)
+            duration = xcOptional(element: "duration", from: json) ?? 0.0
             subtestGroups = xcArray(element: "subtests", from: json)
                 .ofType(ActionTestSummaryGroup.self)
             subtests = xcArray(element: "subtests", from: json)


### PR DESCRIPTION
The `duration` field is not included in the `.xcresults` bundle data when a test group is composed of only tests which crashed during the test run. Requiring `duration` here causes the entire test group parsing to fail.

To reproduce the issue that this fixes, try creating a test suite with a single test that has a `fatalError` call. Process the output and you'll see that a `Summary` is generated for the test suite, and metrics show 1 run test, 1 failed... but the actual Group (and hence dependent test objects) will not be included in the `ActionsInvocationRecord` returned by `getInvocationRecord()`.