### PR TITLE
Setting ActionTestSummaryGroup name and identifier params as optional

### DIFF
--- a/Sources/XCResultKit/ActionTestSummaryGroup.swift
+++ b/Sources/XCResultKit/ActionTestSummaryGroup.swift
@@ -14,24 +14,20 @@
 import Foundation
 
 public struct ActionTestSummaryGroup: XCResultObject {
-    public let name: String
-    public let identifier: String
+    public let name: String?
+    public let identifier: String?
     public let duration: Double
     public let subtestGroups: [ActionTestSummaryGroup]
     public let subtests: [ActionTestMetadata]
     
     public init?(_ json: [String: AnyObject]) {
-        do {
-            name = try xcRequired(element: "name", from: json)
-            identifier = try xcRequired(element: "identifier", from: json)
-            duration = xcOptional(element: "duration", from: json) ?? 0.0
-            subtestGroups = xcArray(element: "subtests", from: json)
-                .ofType(ActionTestSummaryGroup.self)
-            subtests = xcArray(element: "subtests", from: json)
-                .ofType(ActionTestMetadata.self)
-        } catch {
-            logError("Error parsing ActionTestSummaryGroup: \(error.localizedDescription)")
-            return nil
-        }
+        name = xcOptional(element: "name", from: json)
+        identifier = xcOptional(element: "identifier", from: json)
+        duration = xcOptional(element: "duration", from: json) ?? 0.0
+        subtestGroups = xcArray(element: "subtests", from: json)
+            .ofType(ActionTestSummaryGroup.self)
+        subtests = xcArray(element: "subtests", from: json)
+            .ofType(ActionTestMetadata.self)
+        
     }
 }


### PR DESCRIPTION
Upon switching to 12.5.1 I found some new issues with properties not provided in xcresult bundles