### PR TITLE
✨ Add repetitionPolicySummary support introduced with Xcode 13's test retry features

### DIFF
--- a/Sources/XCResultKit/ActionTestRepetitionPolicySummary.swift
+++ b/Sources/XCResultKit/ActionTestRepetitionPolicySummary.swift
@@ -1,0 +1,31 @@
+//
+//  ActionTestRepetitionPolicySummary.swift
+//  
+//
+//  Created by Tyler Vick on 12/21/21.
+//
+
+import Foundation
+
+public struct ActionTestRepetitionPolicySummary: XCResultObject {
+    
+    public let iteration: Int
+    public let totalIterations: Int
+    public let repetitionMode: RepetitionMode
+    
+    public init?(_ json: [String: AnyObject]) {
+        do {
+            iteration = try xcRequired(element: "iteration", from: json)
+            totalIterations = try xcRequired(element: "totalIterations", from: json)
+            repetitionMode = RepetitionMode(rawValue: try xcRequired(element: "repetitionMode", from: json))!
+        } catch {
+            logError("Error parsing \(String(describing: ActionTestRepetitionPolicySummary.self)): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+}
+
+public enum RepetitionMode: String {
+    case runRetryOnFailure = "RunRetryOnFailure"
+}

--- a/Sources/XCResultKit/ActionTestRepetitionPolicySummary.swift
+++ b/Sources/XCResultKit/ActionTestRepetitionPolicySummary.swift
@@ -11,13 +11,13 @@ public struct ActionTestRepetitionPolicySummary: XCResultObject {
     
     public let iteration: Int
     public let totalIterations: Int
-    public let repetitionMode: RepetitionMode
+    public let repetitionMode: RepetitionMode?
     
     public init?(_ json: [String: AnyObject]) {
         do {
             iteration = try xcRequired(element: "iteration", from: json)
             totalIterations = try xcRequired(element: "totalIterations", from: json)
-            repetitionMode = RepetitionMode(rawValue: try xcRequired(element: "repetitionMode", from: json))!
+            repetitionMode = RepetitionMode.from(xcOptional(element: "repetitionMode", from: json))
         } catch {
             logError("Error parsing \(String(describing: ActionTestRepetitionPolicySummary.self)): \(error.localizedDescription)")
             return nil
@@ -27,5 +27,15 @@ public struct ActionTestRepetitionPolicySummary: XCResultObject {
 }
 
 public enum RepetitionMode: String {
+    case none = "None"
+    case runUntilFailure = "RunUntilFailure"
     case runRetryOnFailure = "RunRetryOnFailure"
+    case upUntilMaximumRepetitions = "FixedIterations"
+    
+    static func from(_ str: String?) -> Self? {
+        if let str = str {
+            return self.init(rawValue: str)
+        }
+        return nil
+    }
 }

--- a/Sources/XCResultKit/ActionTestSummary.swift
+++ b/Sources/XCResultKit/ActionTestSummary.swift
@@ -25,6 +25,7 @@ public struct ActionTestSummary: XCResultObject {
     public let performanceMetrics: [ActionTestPerformanceMetricSummary]
     public let failureSummaries: [ActionTestFailureSummary]
     public let activitySummaries: [ActionTestActivitySummary]
+    public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
 
     public init?(_ json: [String: AnyObject]) {
         do {
@@ -38,6 +39,7 @@ public struct ActionTestSummary: XCResultObject {
                 .ofType(ActionTestFailureSummary.self)
             activitySummaries = xcArray(element: "activitySummaries", from: json)
                 .ofType(ActionTestActivitySummary.self)
+            repetitionPolicySummary = xcOptional(element: "repetitionPolicySummary", from: json)
         } catch {
             logError("Error parsing ActionTestSummary: \(error.localizedDescription)")
             return nil

--- a/Tests/XCResultKitTests/ActionTestSummaryTests.swift
+++ b/Tests/XCResultKitTests/ActionTestSummaryTests.swift
@@ -9,6 +9,16 @@ final class ActionTestSummaryTests: XCTestCase {
         XCTAssertNotNil(record)
         XCTAssertGreaterThan(record!.activitySummaries.count, 0)
     }
+    
+    func testCanParseRepetitionPolicy() throws {
+        let ats = try XCTUnwrap(ActionTestSummary(parse(actionTestSummaryWithRepetitionSummary)))
+        
+        let repetitionPolicy = try XCTUnwrap(ats.repetitionPolicySummary)
+        
+        XCTAssertEqual(repetitionPolicy.repetitionMode, .runRetryOnFailure)
+        XCTAssertEqual(repetitionPolicy.totalIterations, 2)
+        XCTAssertEqual(repetitionPolicy.iteration, 1)
+    }
 
     static var allTests = [
         ("testCanParseCorrectlyFormattedJSON", testCanParseCorrectlyFormattedJSON),
@@ -304,4 +314,248 @@ final class ActionTestSummaryTests: XCTestCase {
     }
 }
 """
+    
+    let actionTestSummaryWithRepetitionSummary = """
+{
+  "_type" : {
+    "_name" : "ActionTestSummary",
+    "_supertype" : {
+      "_name" : "ActionTestSummaryIdentifiableObject",
+      "_supertype" : {
+        "_name" : "ActionAbstractTestSummary"
+      }
+    }
+  },
+  "activitySummaries" : {
+    "_type" : {
+      "_name" : "Array"
+    },
+    "_values" : [
+      {
+        "_type" : {
+          "_name" : "ActionTestActivitySummary"
+        },
+        "activityType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.xctest.activity-type.internal"
+        },
+        "finish" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.712-0700"
+        },
+        "start" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.690-0700"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Start Test at 2021-12-21 13:29:05.690"
+        },
+        "uuid" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "7EFFB7B6-FE6C-4635-B47F-CCBDE6C940FF"
+        }
+      },
+      {
+        "_type" : {
+          "_name" : "ActionTestActivitySummary"
+        },
+        "activityType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.xctest.activity-type.deletedAttachment"
+        },
+        "finish" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.690-0700"
+        },
+        "start" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.690-0700"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Some screenshots were deleted because testing is configured to remove automatic screenshots on success."
+        },
+        "uuid" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "5A2D2FBF-973F-4C54-937B-680CFF6B5B45"
+        }
+      },
+      {
+        "_type" : {
+          "_name" : "ActionTestActivitySummary"
+        },
+        "activityType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.xctest.activity-type.internal"
+        },
+        "finish" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.714-0700"
+        },
+        "start" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.713-0700"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Set Up"
+        },
+        "uuid" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "5A63EA34-2CF4-47C3-8D73-78F69BCEB356"
+        }
+      },
+      {
+        "_type" : {
+          "_name" : "ActionTestActivitySummary"
+        },
+        "activityType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.xctest.activity-type.userCreated"
+        },
+        "finish" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.716-0700"
+        },
+        "start" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.715-0700"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Retryable Activity"
+        },
+        "uuid" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "BE88AAD4-3613-4AE8-8AEE-85DD3D09B2AC"
+        }
+      },
+      {
+        "_type" : {
+          "_name" : "ActionTestActivitySummary"
+        },
+        "activityType" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "com.apple.dt.xctest.activity-type.internal"
+        },
+        "finish" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.717-0700"
+        },
+        "start" : {
+          "_type" : {
+            "_name" : "Date"
+          },
+          "_value" : "2021-12-21T13:29:05.716-0700"
+        },
+        "title" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "Tear Down"
+        },
+        "uuid" : {
+          "_type" : {
+            "_name" : "String"
+          },
+          "_value" : "5170EA32-DEE9-40A8-A87E-634EB7967081"
+        }
+      }
+    ]
+  },
+  "duration" : {
+    "_type" : {
+      "_name" : "Double"
+    },
+    "_value" : "0.041687965393066406"
+  },
+  "identifier" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "RetryTests/testRetryOnFailure()"
+  },
+  "name" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "testRetryOnFailure()"
+  },
+  "repetitionPolicySummary" : {
+    "_type" : {
+      "_name" : "ActionTestritionPolicySummary"
+    },
+    "iteration" : {
+      "_type" : {
+        "_name" : "Int"
+      },
+      "_value" : "1"
+    },
+    "repetitionMode" : {
+      "_type" : {
+        "_name" : "String"
+      },
+      "_value" : "RunRetryOnFailure"
+    },
+    "totalIterations" : {
+      "_type" : {
+        "_name" : "Int"
+      },
+      "_value" : "2"
+    }
+  },
+  "testStatus" : {
+    "_type" : {
+      "_name" : "String"
+    },
+    "_value" : "Success"
+  }
+}
+"""
+
 }


### PR DESCRIPTION
Xcode 13 introduced several retry policies and test iterations. We need to read these repetition values to determine if tests should be marked as "Mixed" (i.e. A combination of passing/failing executions) vs. split out into individual test executions.

When multiple tests are executing within these policies, they will be grouped into a single test containing subtests labelled "Iteration 1, Iteration 2, ...".

Changes:

- Add `repetitionPolicySummary` as a new optional property of `ActionTestSummary`
- Create `ActionTestRepetitionPolicySummary` struct with iteration, totalIterations, and optional repetitionMode enum
- Update ActionTestSummaryTests to include parsing case for repetitionPolicySummary