### PR TITLE
Make isTopLevelFailure property optional

### DIFF
--- a/Sources/XCResultKit/Schema/ActionTestExpectedFailure.swift
+++ b/Sources/XCResultKit/Schema/ActionTestExpectedFailure.swift
@@ -22,15 +22,10 @@ public struct ActionTestExpectedFailure: XCResultObject {
     public let failureSummary: ActionTestFailureSummary?
     public let isTopLevelFailure: Bool
 
-    public init?(_ json: [String: AnyObject]) {
-        do {
-            uuid = xcOptional(element: "uuid", from: json)
-            failureReason = xcOptional(element: "failureReason", from: json)
-            failureSummary = xcOptional(element: "failureSummary", from: json)
-            isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
-        } catch {
-            logError("Error parsing ActionTestExpectedFailure: \(error.localizedDescription)")
-            return nil
-        }
+    public init(_ json: [String: AnyObject]) {
+        uuid = xcOptional(element: "uuid", from: json)
+        failureReason = xcOptional(element: "failureReason", from: json)
+        failureSummary = xcOptional(element: "failureSummary", from: json)
+        isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
     }
 }

--- a/Sources/XCResultKit/Schema/ActionTestExpectedFailure.swift
+++ b/Sources/XCResultKit/Schema/ActionTestExpectedFailure.swift
@@ -27,7 +27,7 @@ public struct ActionTestExpectedFailure: XCResultObject {
             uuid = xcOptional(element: "uuid", from: json)
             failureReason = xcOptional(element: "failureReason", from: json)
             failureSummary = xcOptional(element: "failureSummary", from: json)
-            isTopLevelFailure = try xcRequired(element: "isTopLevelFailure", from: json)
+            isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
         } catch {
             logError("Error parsing ActionTestExpectedFailure: \(error.localizedDescription)")
             return nil

--- a/Sources/XCResultKit/Schema/ActionTestFailureSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestFailureSummary.swift
@@ -49,7 +49,7 @@ public struct ActionTestFailureSummary: XCResultObject {
             associatedError = xcOptional(element: "associatedError", from: json)
             sourceCodeContext = xcOptional(element: "sourceCodeContext", from: json)
             timestamp = xcOptional(element: "timestamp", from: json)
-            isTopLevelFailure = try xcRequired(element: "isTopLevelFailure", from: json)
+            isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
         } catch {
             logError("Error parsing ActionTestExpectedFailure: \(error.localizedDescription)")
             return nil


### PR DESCRIPTION
Property `isTopLevelFailure` should be optional in both `ActionTestExpectedFailure` and `ActionTestFailureSummary`.

Here is an example of test case and extracted info:

<img width="876" alt="Screen Shot 2022-11-06 at 15 18 44" src="https://user-images.githubusercontent.com/1695403/200170422-76555955-9f7a-4d60-81ae-6f27bb531d10.png">

https://gist.github.com/kvld/5d269d2d9eaef66e9013bb137d3c902c

In the case of failures in substeps, property `isTopLevelFailure` is missed (because of default value), so XCResultKit will throw an error.