### PR TITLE
Make XCResultObject encodable, export as JSON

### DIFF
--- a/Sources/XCResultKit/Schema/ActionResult.swift
+++ b/Sources/XCResultKit/Schema/ActionResult.swift
@@ -25,11 +25,11 @@ public struct ActionResult: XCResultObject {
     public let metrics: ResultMetrics
     public let issues: ResultIssueSummaries
     public let coverage: CodeCoverageInfo
-    public let timelineRef: Reference?
-    public let logRef: Reference?
-    public let testsRef: Reference?
-    public let diagnosticsRef: Reference?
-    public let consoleLogRef: Reference?
+    public let timelineRef: Reference<GenericReferencedObject>?
+    public let logRef: Reference<ActivityLogSection>?
+    public let testsRef: Reference<ActionTestPlanRunSummaries>?
+    public let diagnosticsRef: Reference<GenericReferencedObject>?
+    public let consoleLogRef: Reference<GenericReferencedObject>?
 
     public init?(_ json: [String: AnyObject]) {
         

--- a/Sources/XCResultKit/Schema/ActionTestAttachment.swift
+++ b/Sources/XCResultKit/Schema/ActionTestAttachment.swift
@@ -28,7 +28,7 @@ public struct ActionTestAttachment: XCResultObject {
     public let lifetime: String
     public let inActivityIdentifier: Int
     public let filename: String?
-    public let payloadRef: Reference?
+    public let payloadRef: Reference<GenericReferencedObject>?
     public let payloadSize: Int
 
     public init?(_ json: [String: AnyObject]) {

--- a/Sources/XCResultKit/Schema/ActionTestMetadata.swift
+++ b/Sources/XCResultKit/Schema/ActionTestMetadata.swift
@@ -26,7 +26,7 @@ public struct ActionTestMetadata: XCResultObject  {
     
     public let testStatus: String
     public let duration: Double?
-    public let summaryRef: Reference?
+    public let summaryRef: Reference<ActionTestSummary>?
     public let performanceMetricsCount: Int?
     public let failureSummariesCount: Int?
     public let activitySummariesCount: Int?

--- a/Sources/XCResultKit/Schema/ActionTestRepetitionPolicySummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestRepetitionPolicySummary.swift
@@ -26,7 +26,7 @@ public struct ActionTestRepetitionPolicySummary: XCResultObject {
 
 }
 
-public enum RepetitionMode: String {
+public enum RepetitionMode: String, Encodable {
     case none = "None"
     case runUntilFailure = "RunUntilFailure"
     case runRetryOnFailure = "RunRetryOnFailure"

--- a/Sources/XCResultKit/Schema/ActionsInvocationRecord.swift
+++ b/Sources/XCResultKit/Schema/ActionsInvocationRecord.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 public struct ActionsInvocationRecord: XCResultObject {
-    public let metadataRef: Reference?
+    public let metadataRef: Reference<GenericReferencedObject>?
     public let metrics: ResultMetrics
     public let issues: ResultIssueSummaries
     public let actions: [ActionRecord]

--- a/Sources/XCResultKit/Schema/CodeCoverageInfo.swift
+++ b/Sources/XCResultKit/Schema/CodeCoverageInfo.swift
@@ -15,8 +15,8 @@ import Foundation
 
 public struct CodeCoverageInfo: XCResultObject {
     public let hasCoverageData: Bool?
-    public let reportRef: Reference?
-    public let archiveRef: Reference?
+    public let reportRef: Reference<GenericReferencedObject>?
+    public let archiveRef: Reference<GenericReferencedObject>?
     
     public init?(_ json: [String: AnyObject]) {
         hasCoverageData = xcOptional(element: "hasCoverageData", from: json)

--- a/Sources/XCResultKit/Schema/Reference.swift
+++ b/Sources/XCResultKit/Schema/Reference.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public struct Reference: XCResultObject {
+public struct Reference<TargetResultObject: XCResultObject>: XCResultObject {
     public let id: String
     public let targetType: TypeDefinition?
     
@@ -28,4 +28,31 @@ public struct Reference: XCResultObject {
             return nil
         }
     }
+
+    enum CodingKeys: CodingKey {
+        case id
+        case targetType
+        case referencedObject
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encodeIfPresent(self.targetType, forKey: .targetType)
+        
+        if let xcResultFile = encoder.userInfo[.xcResultFile] as? XCResultFile {
+            let referencedObject = getReferencedObject(file: xcResultFile)
+            try container.encodeIfPresent(referencedObject, forKey: .referencedObject)
+        }
+    }
+
+    private func getReferencedObject(file: XCResultFile) -> TargetResultObject? {
+        guard let rootJson = file.getRootJson(id: id) else {
+            logError("Unable to retrieve json from file: \(file.url) with id: \(id) for expected type: \(TargetResultObject.self)")
+            return nil
+        }
+
+        return TargetResultObject(rootJson)
+    }
+
 }

--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -42,63 +42,42 @@ public class XCResultFile {
     }
     
     public func getTestPlanRunSummaries(id: String) -> ActionTestPlanRunSummaries? {
-        
-        guard let data = xcrun(["xcresulttool", "get", "--path", url.path, "--id", id, "--format", "json"]) else {
+        guard let rootJSON = getRootJson(id: id) else {
             return nil
         }
-        
-        do {
-            guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                logError("Expecting top level dictionary but didn't find one")
-                return nil
-            }
-            
-            let runSummaries = ActionTestPlanRunSummaries(rootJSON)
-            return runSummaries
-        } catch {
-            logError("Error deserializing JSON: \(error)")
-            return nil
-        }
+
+        return ActionTestPlanRunSummaries(rootJSON)
     }
 
     public func getLogs(id: String) -> ActivityLogSection? {
-        guard let data = xcrun(["xcresulttool", "get", "--path", url.path, "--id", id, "--format", "json"]) else {
+        guard let rootJSON = getRootJson(id: id) else {
             return nil
         }
 
-        do {
-            guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                logError("Expecting top level dictionary but didn't find one")
-                return nil
-            }
-
-            return ActivityLogSection(rootJSON)
-        } catch {
-            logError("Error deserializing JSON: \(error)")
-            return nil
-        }
+        return ActivityLogSection(rootJSON)
     }
     
     public func getActionTestSummary(id: String) -> ActionTestSummary? {
-        
-        guard let data = xcrun(["xcresulttool", "get", "--path", url.path, "--id", id, "--format", "json"]) else {
+        guard let rootJSON = getRootJson(id: id) else {
             return nil
         }
         
+        return ActionTestSummary(rootJSON)
+    }
+    
+    func getRootJson(id: String) -> [String: AnyObject]? {
+        guard let data = xcrun(["xcresulttool", "get", "--path", url.path, "--id", id, "--format", "json"]) else {
+            return nil
+        }
+
         do {
-            guard let rootJSON = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject] else {
-                logError("Expecting top level dictionary but didn't find one")
-                return nil
-            }
-            
-            let summary = ActionTestSummary(rootJSON)
-            return summary
+            return try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: AnyObject]
         } catch {
             logError("Error deserializing JSON: \(error)")
             return nil
         }
     }
-    
+
     public func getPayload(id: String) -> Data? {
         
         guard let data = xcrun(["xcresulttool", "get", "--path", url.path, "--id", id]) else {
@@ -113,7 +92,15 @@ public class XCResultFile {
         xcrun(["xcresulttool", "export", "--type", "file", "--path", url.path, "--id", id, "--output-path", tempPath.path], output: .never)
         return tempPath
     }
-    
+
+    /// Encodes the root invocation record and any available referenced objects
+    /// - Returns: A json blob of the invocation record's json structure
+    public func exportRecursiveJson() -> Data? {
+        let encoder = JSONEncoder()
+        encoder.userInfo[.xcResultFile] = self
+        return try? encoder.encode(getInvocationRecord())
+    }
+
     public func getCodeCoverage() -> CodeCoverage? {
         
         guard let data = xcrun(["xccov", "view", "--report", "--json", url.path]) else {
@@ -161,4 +148,8 @@ public class XCResultFile {
             }
         }
     }
+}
+
+public extension CodingUserInfoKey {
+    static let xcResultFile = CodingUserInfoKey(rawValue: "xcResultFile")!
 }

--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -98,6 +98,8 @@ public class XCResultFile {
     public func exportRecursiveJson() -> Data? {
         let encoder = JSONEncoder()
         encoder.userInfo[.xcResultFile] = self
+        // Set Date format to use unix epoch
+        encoder.dateEncodingStrategy = .secondsSince1970
         return try? encoder.encode(getInvocationRecord())
     }
 

--- a/Sources/XCResultKit/XCResultObject.swift
+++ b/Sources/XCResultKit/XCResultObject.swift
@@ -7,8 +7,22 @@
 
 import Foundation
 
-protocol XCResultObject {
+// TODO: This can be replaced with just `Codable`
+public protocol XCResultObject: Encodable {
     init?(_ json: [String: AnyObject])
+}
+
+public struct GenericReferencedObject: XCResultObject {
+    let json: Data
+    
+    public init?(_ json: [String : AnyObject]) {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: json)
+            self.json = jsonData
+        } catch {
+            return nil
+        }
+    }
 }
 
 enum XCResultError: Error {


### PR DESCRIPTION
Add "Encodable" conformance to XCResultObject so the parsed xcresult can be expressed as json/any encodable format. This enables a user to obtain a wholistic single view of the xcresult object.

This change also adds an associated XCResultObject to `Reference` so that consumers can traverse the entire result tree in a single operation.