### PR TITLE
Make inActivityIdentifier optional

### DIFF
--- a/Sources/XCResultKit/Schema/ActionTestAttachment.swift
+++ b/Sources/XCResultKit/Schema/ActionTestAttachment.swift
@@ -26,7 +26,7 @@ public struct ActionTestAttachment: XCResultObject {
     public let timestamp: Date?
     public let userInfo: SortedKeyValueArray?
     public let lifetime: String
-    public let inActivityIdentifier: Int
+    public let inActivityIdentifier: Int?
     public let filename: String?
     public let payloadRef: Reference?
     public let payloadSize: Int
@@ -39,7 +39,7 @@ public struct ActionTestAttachment: XCResultObject {
             timestamp = xcOptional(element: "timestamp", from: json)
             lifetime = try xcRequired(element: "lifetime", from: json)
             userInfo = xcOptional(element: "userInfo", from: json)
-            inActivityIdentifier = try xcRequired(element: "inActivityIdentifier", from: json)
+            inActivityIdentifier = xcOptional(element: "inActivityIdentifier", from: json)
             filename = xcOptional(element: "filename", from: json)
             payloadRef = xcOptional(element: "payloadRef", from: json)
             payloadSize = try xcRequired(element: "payloadSize", from: json)


### PR DESCRIPTION
I ran into a case when tests crash with a fatalError() where this field is optional, not provided by apple (despite it apparently being required in the schema). It was throwing an exception, resulting in a test attachment being unnecessarily dropped. In this case the attachment being dropped was the crash report, which is necessary to help debug a crashed test.