### PR TITLE
update XCResultObjects for xcode 15/xcresulttool 3.44 changes

### DIFF
--- a/Sources/XCResultKit/Schema/ActionTestActivitySummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestActivitySummary.swift
@@ -4,16 +4,19 @@
 //
 //  Created by David House on 7/5/19.
 //
-//- ActionTestActivitySummary
-//    * Kind: object
-//* Properties:
-//+ title: String
-//+ activityType: String
-//+ uuid: String
-//+ start: Date?
-//+ finish: Date?
-//+ attachments: [ActionTestAttachment]
-//+ subactivities: [ActionTestActivitySummary]
+// - ActionTestActivitySummary
+// * Kind: object
+// * Properties:
+//     + title: String
+//     + activityType: String
+//     + uuid: String
+//     + start: Date?
+//     + finish: Date?
+//     + attachments: [ActionTestAttachment]
+//     + subactivities: [ActionTestActivitySummary]
+//     + failureSummaryIDs: [String]
+//     + expectedFailureIDs: [String]
+//     + warningSummaryIDs: [String]
 
 import Foundation
 
@@ -28,6 +31,7 @@ public struct ActionTestActivitySummary: XCResultObject {
     public let subactivities: [ActionTestActivitySummary]
     public let failureSummaryIDs: [String]
     public let expectedFailureIDs: [String]
+    public let warningSummaryIDs: [String]
 
     public init?(_ json: [String: AnyObject]) {
         do {
@@ -42,6 +46,7 @@ public struct ActionTestActivitySummary: XCResultObject {
                 .ofType(ActionTestActivitySummary.self)
             failureSummaryIDs = xcArray(element: "failureSummaryIDs", from: json).ofType(String.self)
             expectedFailureIDs = xcArray(element: "expectedFailureIDs", from: json).ofType(String.self)
+            warningSummaryIDs = xcArray(element: "warningSummaryIDs", from: json).ofType(String.self)
         } catch {
             logError("Error parsing ActionTestActivitySummary: \(error.localizedDescription)")
             return nil

--- a/Sources/XCResultKit/Schema/ActionTestIssueSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestIssueSummary.swift
@@ -1,0 +1,54 @@
+//
+//  ActionTestIssueSummary.swift
+//  
+//
+//  Created by Tyler Vick on 7/10/23.
+//
+// - ActionTestIssueSummary
+// * Kind: object
+// * Properties:
+//     + message: String?
+//     + fileName: String
+//     + lineNumber: Int
+//     + uuid: String
+//     + issueType: String?
+//     + detailedDescription: String?
+//     + attachments: [ActionTestAttachment]
+//     + associatedError: TestAssociatedError?
+//     + sourceCodeContext: SourceCodeContext?
+//     + timestamp: Date?
+
+import Foundation
+
+public struct ActionTestIssueSummary: XCResultObject {
+
+    public let message: String?
+    public let fileName: String
+    public let lineNumber: Int
+    public let uuid: String
+    public let issueType: String?
+    public let detailedDescription: String?
+    public let attachments: [ActionTestAttachment]
+    public let associatedError: TestAssociatedError?
+    public let sourceCodeContext: SourceCodeContext?
+    public let timestamp: Date?
+
+    public init?(_ json: [String: AnyObject]) {
+        do {
+            message = xcOptional(element: "message", from: json)
+            fileName = try xcRequired(element: "fileName", from: json)
+            lineNumber = try xcRequired(element: "lineNumber", from: json)
+            uuid = try xcRequired(element: "uuid", from: json)
+            issueType = xcOptional(element: "issueType", from: json)
+            detailedDescription = xcOptional(element: "detailedDescription", from: json)
+            attachments = xcArray(element: "attachments", from: json)
+                .ofType(ActionTestAttachment.self)
+            associatedError = xcOptional(element: "associatedError", from: json)
+            sourceCodeContext = xcOptional(element: "sourceCodeContext", from: json)
+            timestamp = xcOptional(element: "timestamp", from: json)
+        } catch {
+            logError("Error parsing ActionTestIssueSummary: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/Schema/ActionTestSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestSummary.swift
@@ -4,15 +4,20 @@
 //
 //  Created by David House on 7/5/19.
 //
-//- ActionTestSummary
-//    * Supertype: ActionTestSummaryIdentifiableObject
-//* Kind: object
-//* Properties:
-//+ testStatus: String
-//+ duration: Double
-//+ performanceMetrics: [ActionTestPerformanceMetricSummary]
-//+ failureSummaries: [ActionTestFailureSummary]
-//+ activitySummaries: [ActionTestActivitySummary]
+// - ActionTestSummary
+// * Supertype: ActionTestSummaryIdentifiableObject
+// * Kind: object
+// * Properties:
+//     + testStatus: String
+//     + duration: Double
+//     + performanceMetrics: [ActionTestPerformanceMetricSummary]
+//     + failureSummaries: [ActionTestFailureSummary]
+//     + expectedFailures: [ActionTestExpectedFailure]
+//     + skipNoticeSummary: ActionTestNoticeSummary?
+//     + activitySummaries: [ActionTestActivitySummary]
+//     + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+//     + configuration: ActionTestConfiguration?
+//     + warningSummaries: [ActionTestIssueSummary]
 
 import Foundation
 
@@ -30,6 +35,7 @@ public struct ActionTestSummary: XCResultObject {
     public let activitySummaries: [ActionTestActivitySummary]
     public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
     public let configuration: ActionTestConfiguration?
+    public let warningSummaries: [ActionTestIssueSummary]
     
     public init?(_ json: [String: AnyObject]) {
         do {
@@ -49,6 +55,8 @@ public struct ActionTestSummary: XCResultObject {
                 .ofType(ActionTestActivitySummary.self)
             repetitionPolicySummary = xcOptional(element: "repetitionPolicySummary", from: json)
             configuration = xcOptional(element: "configuration", from: json)
+            warningSummaries = xcArray(element: "warningSummaries", from: json)
+                .ofType(ActionTestIssueSummary.self)
         } catch {
             logError("Error parsing ActionTestSummary: \(error.localizedDescription)")
             return nil

--- a/Sources/XCResultKit/Schema/ConsoleLogItem.swift
+++ b/Sources/XCResultKit/Schema/ConsoleLogItem.swift
@@ -4,22 +4,23 @@
 //
 //  Created by David House on 9/17/22.
 //
+// - ConsoleLogItem
+// * Kind: object
+// * Properties:
+//     + adaptorType: String?
+//     + kind: String?
+//     + timestamp: Double
+//     + content: String
+//     + logData: ConsoleLogItemLogData?
 
 import Foundation
-
-//- ConsoleLogItem
-//  * Kind: object
-//  * Properties:
-//    + adaptorType: String?
-//    + kind: String?
-//    + timestamp: Double
-//    + content: String
 
 public struct ConsoleLogItem: XCResultObject {
     public let adaptorType: String?
     public let kind: String?
     public let timestamp: Double
     public let content: String
+    public let logData: ConsoleLogItemLogData?
     
     public init?(_ json: [String: AnyObject]) {
         do {
@@ -27,6 +28,7 @@ public struct ConsoleLogItem: XCResultObject {
             kind = xcOptional(element: "kind", from: json)
             timestamp = try xcRequired(element: "timestamp", from: json)
             content = try xcRequired(element: "content", from: json)
+            logData = xcOptional(element: "logData", from: json)
         } catch {
             logError("Error parsing ConsoleLogItem: \(error.localizedDescription)")
             return nil

--- a/Sources/XCResultKit/Schema/ConsoleLogItemLogData.swift
+++ b/Sources/XCResultKit/Schema/ConsoleLogItemLogData.swift
@@ -1,0 +1,71 @@
+//
+//  ConsoleLogItemLogData.swift
+//
+//
+//  Created by Tyler Vick on 7/10/23.
+//
+// - ConsoleLogItemLogData
+// * Kind: object
+// * Properties:
+//     + message: String?
+//     + subsystem: String?
+//     + category: String?
+//     + library: String?
+//     + format: String?
+//     + backtrace: String?
+//     + pid: Int32
+//     + processName: String?
+//     + sessionUUID: String?
+//     + tid: UInt64
+//     + messageType: UInt8
+//     + senderImagePath: String?
+//     + senderImageUUID: String?
+//     + senderImageOffset: UInt64
+//     + unixTimeInterval: Double
+//     + timeZone: String?
+
+import Foundation
+
+public struct ConsoleLogItemLogData: XCResultObject {
+
+    public let message: String?
+    public let subsystem: String?
+    public let category: String?
+    public let library: String?
+    public let format: String?
+    public let backtrace: String?
+    public let pid: Int32
+    public let processName: String?
+    public let sessionUUID: String?
+    public let tid: UInt64
+    public let messageType: UInt8
+    public let senderImagePath: String?
+    public let senderImageUUID: String?
+    public let senderImageOffset: UInt64
+    public let unixTimeInterval: Double
+    public let timeZone: String?
+
+    public init?(_ json: [String: AnyObject]) {
+        do {
+            message = xcOptional(element: "message", from: json)
+            subsystem = xcOptional(element: "subsystem", from: json)
+            category = xcOptional(element: "category", from: json)
+            library = xcOptional(element: "library", from: json)
+            format = xcOptional(element: "format", from: json)
+            backtrace = xcOptional(element: "backtrace", from: json)
+            pid = try xcRequired(element: "pid", from: json)
+            processName = xcOptional(element: "processName", from: json)
+            sessionUUID = xcOptional(element: "sessionUUID", from: json)
+            tid = try xcRequired(element: "tid", from: json)
+            messageType = try xcRequired(element: "messageType", from: json)
+            senderImagePath = xcOptional(element: "senderImagePath", from: json)
+            senderImageUUID = xcOptional(element: "senderImageUUID", from: json)
+            senderImageOffset = try xcRequired(element: "senderImageOffset", from: json)
+            unixTimeInterval = try xcRequired(element: "unixTimeInterval", from: json)
+            timeZone = xcOptional(element: "timeZone", from: json)
+        } catch {
+            logError("Error parsing ConsoleLogItemLogData: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/Schema/ResultIssueSummaries.swift
+++ b/Sources/XCResultKit/Schema/ResultIssueSummaries.swift
@@ -4,13 +4,14 @@
 //
 //  Created by David House on 6/30/19.
 //
-//- ResultIssueSummaries
-//    * Kind: object
-//* Properties:
-//+ analyzerWarningSummaries: [IssueSummary]
-//+ errorSummaries: [IssueSummary]
-//+ testFailureSummaries: [TestFailureIssueSummary]
-//+ warningSummaries: [IssueSummary]
+// - ResultIssueSummaries
+// * Kind: object
+// * Properties:
+//     + analyzerWarningSummaries: [IssueSummary]
+//     + errorSummaries: [IssueSummary]
+//     + testFailureSummaries: [TestFailureIssueSummary]
+//     + warningSummaries: [IssueSummary]
+//     + testWarningSummaries: [TestIssueSummary]
 
 import Foundation
 
@@ -19,11 +20,13 @@ public struct ResultIssueSummaries: XCResultObject {
     public let errorSummaries: [IssueSummary]
     public let testFailureSummaries: [TestFailureIssueSummary]
     public let warningSummaries: [IssueSummary]
+    public let testWarningSummaries: [TestIssueSummary]
     
     public init?(_ json: [String: AnyObject]) {        
         analyzerWarningSummaries = xcArray(element: "analyzerWarningSummaries", from: json).ofType(IssueSummary.self)
         errorSummaries = xcArray(element: "errorSummaries", from: json).ofType(IssueSummary.self)
         testFailureSummaries = xcArray(element: "testFailureSummaries", from: json).ofType(TestFailureIssueSummary.self)
         warningSummaries = xcArray(element: "warningSummaries", from: json).ofType(IssueSummary.self)
+        testWarningSummaries = xcArray(element: "testWarningSummaries", from: json).ofType(TestIssueSummary.self)
     }
 }

--- a/Sources/XCResultKit/Schema/ResultMetrics.swift
+++ b/Sources/XCResultKit/Schema/ResultMetrics.swift
@@ -4,14 +4,16 @@
 //
 //  Created by David House on 6/30/19.
 //
-//- ResultMetrics
-//    * Kind: object
-//* Properties:
-//+ analyzerWarningCount: Int
-//+ errorCount: Int
-//+ testsCount: Int
-//+ testsFailedCount: Int
-//+ warningCount: Int
+// - ResultMetrics
+// * Kind: object
+// * Properties:
+//     + analyzerWarningCount: Int
+//     + errorCount: Int
+//     + testsCount: Int
+//     + testsFailedCount: Int
+//     + testsSkippedCount: Int
+//     + warningCount: Int
+//     + totalCoveragePercentage: Double?
 
 import Foundation
 
@@ -22,6 +24,7 @@ public struct ResultMetrics: XCResultObject {
     public let testsFailedCount: Int?
     public let warningCount: Int?
     public let testsSkippedCount: Int?
+    public let totalCoveragePercentage: Double?
     
     public init?(_ json: [String: AnyObject]) {    
         analyzerWarningCount = xcOptional(element: "analyzerWarningCount", from: json)
@@ -30,5 +33,6 @@ public struct ResultMetrics: XCResultObject {
         testsFailedCount = xcOptional(element: "testsFailedCount", from: json)
         warningCount = xcOptional(element: "warningCount", from: json)
         testsSkippedCount = xcOptional(element: "testsSkippedCount", from: json)
+        totalCoveragePercentage = xcOptional(element: "totalCoveragePercentage", from: json)
     }
 }

--- a/Sources/XCResultKit/Schema/TestIssueSummary.swift
+++ b/Sources/XCResultKit/Schema/TestIssueSummary.swift
@@ -1,0 +1,26 @@
+//
+//  TestIssueSummary.swift
+//  XCResultKit
+//
+//  Created by Tyler Vick on 7/10/23.
+//
+// - TestIssueSummary
+// * Supertype: IssueSummary
+// * Kind: object
+// * Properties:
+//     + testCaseName: String
+
+import Foundation
+
+public struct TestIssueSummary: XCResultObject {
+
+    public let testCaseName: String
+
+    public init?(_ json: [String: AnyObject]) {
+        do {
+            testCaseName = try xcRequired(element: "testCaseName", from: json)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/XCResultKit/XCResultInt.swift
+++ b/Sources/XCResultKit/XCResultInt.swift
@@ -24,3 +24,75 @@ extension Int: XCResultObject {
         self = actualValue.integerValue
     }
 }
+
+extension Int8: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Int8" else {
+            logError("Incorrect type, expecting Int8")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? Int8 else {
+            logError("Unable to get int8 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension Int16: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Int16" else {
+            logError("Incorrect type, expecting Int16")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? Int16 else {
+            logError("Unable to get int16 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension Int32: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Int32" else {
+            logError("Incorrect type, expecting Int32")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? Int32 else {
+            logError("Unable to get int32 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension Int64: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "Int64" else {
+            logError("Incorrect type, expecting Int64")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? Int64 else {
+            logError("Unable to get int64 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}

--- a/Sources/XCResultKit/XCResultUInt.swift
+++ b/Sources/XCResultKit/XCResultUInt.swift
@@ -1,0 +1,98 @@
+//
+//  XCResultUInt.swift
+//
+//
+//  Created by Tyler Vick on 7/10/23.
+//
+
+import Foundation
+
+extension UInt: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "UInt" else {
+            logError("Incorrect type, expecting UInt")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? UInt else {
+            logError("Unable to get uint value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension UInt8: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "UInt8" else {
+            logError("Incorrect type, expecting UInt8")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? UInt8 else {
+            logError("Unable to get uint8 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension UInt16: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "UInt16" else {
+            logError("Incorrect type, expecting UInt16")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? UInt16 else {
+            logError("Unable to get uint16 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension UInt32: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "UInt32" else {
+            logError("Incorrect type, expecting UInt32")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? UInt32 else {
+            logError("Unable to get uint32 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}
+
+extension UInt64: XCResultObject {
+
+    public init?(_ json: [String: AnyObject]) {
+        guard let type = json["_type"] as? [String: AnyObject], let name = type["_name"] as? String, name == "UInt64" else {
+            logError("Incorrect type, expecting UInt64")
+            return nil
+        }
+
+        guard let actualValue = json["_value"] as? UInt64 else {
+            logError("Unable to get uint64 value")
+            return nil
+        }
+
+        self = actualValue
+    }
+
+}

--- a/XCResultFormat.md
+++ b/XCResultFormat.md
@@ -1,6 +1,6 @@
 Name: Xcode Result Types
-Version: 3.39
-Signature: PS0lrtUj8Aw=
+Version: 3.44
+Signature: G3FAemVu1AQ=
 Types:
   - ActionAbstractTestSummary
     * Kind: object
@@ -84,6 +84,7 @@ Types:
       + subactivities: [ActionTestActivitySummary]
       + failureSummaryIDs: [String]
       + expectedFailureIDs: [String]
+      + warningSummaryIDs: [String]
   - ActionTestAttachment
     * Kind: object
     * Properties:
@@ -123,6 +124,19 @@ Types:
       + sourceCodeContext: SourceCodeContext?
       + timestamp: Date?
       + isTopLevelFailure: Bool
+  - ActionTestIssueSummary
+    * Kind: object
+    * Properties:
+      + message: String?
+      + fileName: String
+      + lineNumber: Int
+      + uuid: String
+      + issueType: String?
+      + detailedDescription: String?
+      + attachments: [ActionTestAttachment]
+      + associatedError: TestAssociatedError?
+      + sourceCodeContext: SourceCodeContext?
+      + timestamp: Date?
   - ActionTestMetadata
     * Supertype: ActionTestSummaryIdentifiableObject
     * Kind: object
@@ -182,6 +196,7 @@ Types:
       + activitySummaries: [ActionTestActivitySummary]
       + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
       + configuration: ActionTestConfiguration?
+      + warningSummaries: [ActionTestIssueSummary]
   - ActionTestSummaryGroup
     * Supertype: ActionTestSummaryIdentifiableObject
     * Kind: object
@@ -332,6 +347,26 @@ Types:
       + kind: String?
       + timestamp: Double
       + content: String
+      + logData: ConsoleLogItemLogData?
+  - ConsoleLogItemLogData
+    * Kind: object
+    * Properties:
+      + message: String?
+      + subsystem: String?
+      + category: String?
+      + library: String?
+      + format: String?
+      + backtrace: String?
+      + pid: Int32
+      + processName: String?
+      + sessionUUID: String?
+      + tid: UInt64
+      + messageType: UInt8
+      + senderImagePath: String?
+      + senderImageUUID: String?
+      + senderImageOffset: UInt64
+      + unixTimeInterval: Double
+      + timeZone: String?
   - ConsoleLogSection
     * Kind: object
     * Properties:
@@ -354,6 +389,14 @@ Types:
       + entityType: String
       + sharedState: String
   - Int
+    * Kind: value
+  - Int16
+    * Kind: value
+  - Int32
+    * Kind: value
+  - Int64
+    * Kind: value
+  - Int8
     * Kind: value
   - IssueSummary
     * Kind: object
@@ -378,6 +421,7 @@ Types:
       + errorSummaries: [IssueSummary]
       + testFailureSummaries: [TestFailureIssueSummary]
       + warningSummaries: [IssueSummary]
+      + testWarningSummaries: [TestIssueSummary]
   - ResultMetrics
     * Kind: object
     * Properties:
@@ -387,6 +431,7 @@ Types:
       + testsFailedCount: Int
       + testsSkippedCount: Int
       + warningCount: Int
+      + totalCoveragePercentage: Double?
   - SortedKeyValueArray
     * Kind: object
     * Properties:
@@ -430,8 +475,21 @@ Types:
     * Kind: object
     * Properties:
       + testCaseName: String
+  - TestIssueSummary
+    * Supertype: IssueSummary
+    * Kind: object
+    * Properties:
+      + testCaseName: String
   - TypeDefinition
     * Kind: object
     * Properties:
       + name: String
       + supertype: TypeDefinition?
+  - UInt16
+    * Kind: value
+  - UInt32
+    * Kind: value
+  - UInt64
+    * Kind: value
+  - UInt8
+    * Kind: value


### PR DESCRIPTION
Pull xcresult schema changes from Xcode 15 (beta 3 build 15A5195k) and update XCResultObjects

Run `xcrun xcresulttool formatDescription`, write changes to `XCResultFormat.md`

New objects:
- ActionTestIssueSummary
- ConsoleLogItemLogData
- TestIssueSummary
- Int8
- Int16
- Int32
- Int64
- UInt8
- UInt16
- UInt32
- UInt64


Notably, the int/uint changes are implemented differently from existing the existing Int. NSString cannot be easily converted to uint without precision loss. Instead we'll utilize the Swift "Int/UInt" string initializers.