### PR TITLE
Make `ActionTestAttachment.payloadSize` optional

### DIFF
--- a/Sources/XCResultKit/Schema/ActionTestAttachment.swift
+++ b/Sources/XCResultKit/Schema/ActionTestAttachment.swift
@@ -29,7 +29,7 @@ public struct ActionTestAttachment: XCResultObject {
     public let inActivityIdentifier: Int?
     public let filename: String?
     public let payloadRef: Reference<GenericReferencedObject>?
-    public let payloadSize: Int
+    public let payloadSize: Int?
 
     public init?(_ json: [String: AnyObject]) {
         do {
@@ -42,7 +42,7 @@ public struct ActionTestAttachment: XCResultObject {
             inActivityIdentifier = xcOptional(element: "inActivityIdentifier", from: json)
             filename = xcOptional(element: "filename", from: json)
             payloadRef = xcOptional(element: "payloadRef", from: json)
-            payloadSize = try xcRequired(element: "payloadSize", from: json)
+            payloadSize = xcOptional(element: "payloadSize", from: json)
         } catch {
             logError("Error parsing ActionTestAttachment: \(error.localizedDescription)")
             return nil


### PR DESCRIPTION
Even though it should not be optional according to Apples docs, it definitely is.

Can be reproduced with this xcresult bundle created by Xcode 15.1:
[Fixture.xcresult.zip](https://github.com/davidahouse/XCResultKit/files/14211042/Fixture.xcresult.zip)
