### PR TITLE
Xcode 16.0 schema changes

### DIFF
--- a/Sources/XCResultKit/Schema/ActionTestFailureSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestFailureSummary.swift
@@ -1,58 +1,61 @@
 //
-//  File.swift
-//  
+//  ActionTestFailureSummary.swift
+//
 //
 //  Created by David House on 7/3/19.
 //
 //- ActionTestFailureSummary
 //  * Kind: object
 //  * Properties:
-//    + message: String?
-//    + fileName: String
-//    + lineNumber: Int
-//    + isPerformanceFailure: Bool
-//    + uuid: String
-//    + issueType: String?
-//    + detailedDescription: String?
-//    + attachments: [ActionTestAttachment]
-//    + associatedError: TestAssociatedError?
-//    + sourceCodeContext: SourceCodeContext?
-//    + timestamp: Date?
-//    + isTopLevelFailure: Bool
-
+//	+ message: String?
+//	+ fileName: String
+//	+ lineNumber: Int
+//	+ isPerformanceFailure: Bool
+//	+ uuid: String
+//	+ issueType: String?
+//	+ detailedDescription: String?
+//	+ attachments: [ActionTestAttachment]
+//	+ associatedError: TestAssociatedError?
+//	+ sourceCodeContext: SourceCodeContext?
+//	+ timestamp: Date?
+//	+ isTopLevelFailure: Bool
+//	+ expression: TestExpression?
 import Foundation
 
 public struct ActionTestFailureSummary: XCResultObject {
-    public let message: String?
-    public let fileName: String?
-    public let lineNumber: Int
-    public let isPerformanceFailure: Bool
-    public let uuid: String
-    public let issueType: String?
-    public let detailedDescription: String?
-    public let attachments: [ActionTestAttachment]
-    public let associatedError: TestAssociatedError?
-    public let sourceCodeContext: SourceCodeContext?
-    public let timestamp: Date?
-    public let isTopLevelFailure: Bool
-    
-    public init?(_ json: [String: AnyObject]) {
-        do {
-            message = xcOptional(element: "message", from: json)
-            fileName = xcOptional(element: "fileName", from: json)
-            lineNumber = xcOptional(element: "lineNumber", from: json) ?? 0
-            isPerformanceFailure = xcOptional(element: "isPerformanceFailure", from: json) ?? false
-            uuid = try xcRequired(element: "uuid", from: json)
-            issueType = xcOptional(element: "issueType", from: json)
-            detailedDescription = xcOptional(element: "detailedDescription", from: json)
-            attachments = xcArray(element: "attachments", from: json).ofType(ActionTestAttachment.self)
-            associatedError = xcOptional(element: "associatedError", from: json)
-            sourceCodeContext = xcOptional(element: "sourceCodeContext", from: json)
-            timestamp = xcOptional(element: "timestamp", from: json)
-            isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
-        } catch {
-            logError("Error parsing ActionTestExpectedFailure: \(error.localizedDescription)")
-            return nil
-        }
-    }
+	public let message: String?
+	public let fileName: String?
+	public let lineNumber: Int
+	public let isPerformanceFailure: Bool
+	public let uuid: String
+	public let issueType: String?
+	public let detailedDescription: String?
+	public let attachments: [ActionTestAttachment]
+	public let associatedError: TestAssociatedError?
+	public let sourceCodeContext: SourceCodeContext?
+	public let timestamp: Date?
+	public let isTopLevelFailure: Bool
+	public let expression: TestExpression?
+	
+	public init?(_ json: [String: AnyObject]) {
+		do {
+			message = xcOptional(element: "message", from: json)
+			fileName = xcOptional(element: "fileName", from: json)
+			lineNumber = xcOptional(element: "lineNumber", from: json) ?? 0
+			isPerformanceFailure = xcOptional(element: "isPerformanceFailure", from: json) ?? false
+			uuid = try xcRequired(element: "uuid", from: json)
+			issueType = xcOptional(element: "issueType", from: json)
+			detailedDescription = xcOptional(element: "detailedDescription", from: json)
+			attachments = xcArray(element: "attachments", from: json).ofType(ActionTestAttachment.self)
+			associatedError = xcOptional(element: "associatedError", from: json)
+			sourceCodeContext = xcOptional(element: "sourceCodeContext", from: json)
+			timestamp = xcOptional(element: "timestamp", from: json)
+			isTopLevelFailure = xcOptional(element: "isTopLevelFailure", from: json) ?? false
+			expression = xcOptional(element: "expression", from: json)
+		
+		} catch {
+			logError("Error parsing ActionTestExpectedFailure: \(error.localizedDescription)")
+			return nil
+		}
+	}
 }

--- a/Sources/XCResultKit/Schema/ActionTestSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestSummary.swift
@@ -1,65 +1,86 @@
 //
 //  ActionTestSummary.swift
-//  
+//
 //
 //  Created by David House on 7/5/19.
 //
-// - ActionTestSummary
-// * Supertype: ActionTestSummaryIdentifiableObject
-// * Kind: object
-// * Properties:
-//     + testStatus: String
-//     + duration: Double
-//     + performanceMetrics: [ActionTestPerformanceMetricSummary]
-//     + failureSummaries: [ActionTestFailureSummary]
-//     + expectedFailures: [ActionTestExpectedFailure]
-//     + skipNoticeSummary: ActionTestNoticeSummary?
-//     + activitySummaries: [ActionTestActivitySummary]
-//     + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
-//     + configuration: ActionTestConfiguration?
-//     + warningSummaries: [ActionTestIssueSummary]
+//  - ActionTestSummary
+//    * Supertype: ActionTestSummaryIdentifiableObject
+//    * Kind: object
+//    * Properties:
+//	  + testStatus: String
+//	  + duration: Double
+//	  + performanceMetrics: [ActionTestPerformanceMetricSummary]
+//	  + failureSummaries: [ActionTestFailureSummary]
+//	  + expectedFailures: [ActionTestExpectedFailure]
+//	  + skipNoticeSummary: ActionTestNoticeSummary?
+//	  + activitySummaries: [ActionTestActivitySummary]
+//	  + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+//	  + arguments: [TestArgument]
+//	  + configuration: ActionTestConfiguration?
+//	  + warningSummaries: [ActionTestIssueSummary]
+//	  + summary: String?
+//	  + documentation: [TestDocumentation]
+//	  + trackedIssues: [IssueTrackingMetadata]
+//	  + tags: [TestTag]
 
 import Foundation
 
 public struct ActionTestSummary: XCResultObject {
-    public let identifier: String?
-    public let identifierURL: String?
-    public let name: String?
-    
-    public let testStatus: String
-    public let duration: Double
-    public let performanceMetrics: [ActionTestPerformanceMetricSummary]
-    public let failureSummaries: [ActionTestFailureSummary]
-    public let expectedFailures: [ActionTestExpectedFailure]
-    public let skipNoticeSummary: ActionTestNoticeSummary?
-    public let activitySummaries: [ActionTestActivitySummary]
-    public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
-    public let configuration: ActionTestConfiguration?
-    public let warningSummaries: [ActionTestIssueSummary]
-    
-    public init?(_ json: [String: AnyObject]) {
-        do {
-            identifier = xcOptional(element: "identifier", from: json)
-            identifierURL = xcOptional(element: "identifierURL", from: json)
-            name = xcOptional(element: "name", from: json)
-            
-            testStatus = try xcRequired(element: "testStatus", from: json)
-            duration = xcOptional(element: "duration", from: json) ?? 0
-            performanceMetrics = xcArray(element: "performanceMetrics", from: json)
-                .ofType(ActionTestPerformanceMetricSummary.self)
-            failureSummaries = xcArray(element: "failureSummaries", from: json)
-                .ofType(ActionTestFailureSummary.self)
-            expectedFailures = xcArray(element: "expectedFailures", from: json).ofType(ActionTestExpectedFailure.self)
-            skipNoticeSummary = xcOptional(element: "skipNoticeSummary", from: json)
-            activitySummaries = xcArray(element: "activitySummaries", from: json)
-                .ofType(ActionTestActivitySummary.self)
-            repetitionPolicySummary = xcOptional(element: "repetitionPolicySummary", from: json)
-            configuration = xcOptional(element: "configuration", from: json)
-            warningSummaries = xcArray(element: "warningSummaries", from: json)
-                .ofType(ActionTestIssueSummary.self)
-        } catch {
-            logError("Error parsing ActionTestSummary: \(error.localizedDescription)")
-            return nil
-        }
-    }
+	public let identifier: String?
+	public let identifierURL: String?
+	public let name: String?
+	
+	public let testStatus: String
+	public let duration: Double
+	public let performanceMetrics: [ActionTestPerformanceMetricSummary]
+	public let failureSummaries: [ActionTestFailureSummary]
+	public let expectedFailures: [ActionTestExpectedFailure]
+	public let skipNoticeSummary: ActionTestNoticeSummary?
+	public let activitySummaries: [ActionTestActivitySummary]
+	public let repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+	public let arguments: [TestArgument]?
+	public let configuration: ActionTestConfiguration?
+	public let warningSummaries: [ActionTestIssueSummary]
+	public let summary: String?
+	public let documentation: [TestDocumentation]
+	public let trackedIssues: [IssueTrackingMetadata]?
+	public let tags: [TestTag]?
+
+
+	public init?(_ json: [String: AnyObject]) {
+		do {
+			identifier = xcOptional(element: "identifier", from: json)
+			identifierURL = xcOptional(element: "identifierURL", from: json)
+			name = xcOptional(element: "name", from: json)
+			
+			testStatus = try xcRequired(element: "testStatus", from: json)
+			duration = xcOptional(element: "duration", from: json) ?? 0
+			performanceMetrics = xcArray(element: "performanceMetrics", from: json)
+				.ofType(ActionTestPerformanceMetricSummary.self)
+			failureSummaries = xcArray(element: "failureSummaries", from: json)
+				.ofType(ActionTestFailureSummary.self)
+			expectedFailures = xcArray(element: "expectedFailures", from: json).ofType(ActionTestExpectedFailure.self)
+			skipNoticeSummary = xcOptional(element: "skipNoticeSummary", from: json)
+			activitySummaries = xcArray(element: "activitySummaries", from: json)
+				.ofType(ActionTestActivitySummary.self)
+			repetitionPolicySummary = xcOptional(element: "repetitionPolicySummary", from: json)
+			arguments = xcArray(element: "arguments", from: json)
+				.ofType(TestArgument.self)
+			configuration = xcOptional(element: "configuration", from: json)
+			warningSummaries = xcArray(element: "warningSummaries", from: json)
+				.ofType(ActionTestIssueSummary.self)
+			summary = xcOptional(element: "summary", from: json)
+			documentation = xcArray(element: "documentation", from: json)
+				.ofType(TestDocumentation.self)
+			trackedIssues = xcArray(element: "trackedIssues", from: json)
+				.ofType(IssueTrackingMetadata.self)
+			tags = xcArray(element: "tags", from: json)
+				.ofType(TestTag.self)
+			
+		} catch {
+			logError("Error parsing ActionTestSummary: \(error.localizedDescription)")
+			return nil
+		}
+	}
 }

--- a/Sources/XCResultKit/Schema/ActionTestSummaryGroup.swift
+++ b/Sources/XCResultKit/Schema/ActionTestSummaryGroup.swift
@@ -1,6 +1,6 @@
 //
-//  File.swift
-//  
+//  ActionTestSummaryGroup.swift
+//
 //
 //  Created by David House on 7/3/19.
 //
@@ -10,29 +10,48 @@
 //* Properties:
 //+ duration: Double
 //+ subtests: [ActionTestSummaryIdentifiableObject]
-
+//+ skipNoticeSummary: ActionTestNoticeSummary?
+//+ summary: String?
+//+ documentation: [TestDocumentation]
+//+ trackedIssues: [IssueTrackingMetadata]
+//+ tags: [TestTag]
+//
+// Note that the actual json differs from the schema definition, the type is different for subtests, and subtestGroups does not exist in the schema
 import Foundation
 
-public struct ActionTestSummaryGroup: XCResultObject {
-    public let identifier: String?
-    public let identifierURL: String?
-    public let name: String?
-        
-    public let duration: Double
-    
-    public let subtestGroups: [ActionTestSummaryGroup]
-    public let subtests: [ActionTestMetadata]
-    
-    public init?(_ json: [String: AnyObject]) {
-        identifier = xcOptional(element: "identifier", from: json)
-        identifierURL = xcOptional(element: "identifierURL", from: json)
-        name = xcOptional(element: "name", from: json)
-        
-        duration = xcOptional(element: "duration", from: json) ?? 0.0
-        subtestGroups = xcArray(element: "subtests", from: json)
-            .ofType(ActionTestSummaryGroup.self)
-        subtests = xcArray(element: "subtests", from: json)
-            .ofType(ActionTestMetadata.self)
-        
-    }
+public class ActionTestSummaryGroup: XCResultObject {
+	public let identifier: String?
+	public let identifierURL: String?
+	public let name: String?
+		
+	public let duration: Double
+	
+	public let subtests: [ActionTestMetadata]
+	public let subtestGroups: [ActionTestSummaryGroup]
+	public let skipNoticeSummary: ActionTestNoticeSummary?
+	
+	public let summary: String?
+	public let trackedIssues: [IssueTrackingMetadata]?
+	public let tags: [TestTag]?
+	public let documentation: [TestDocumentation]
+
+	required public init?(_ json: [String: AnyObject]) {
+		identifier = xcOptional(element: "identifier", from: json)
+		identifierURL = xcOptional(element: "identifierURL", from: json)
+		name = xcOptional(element: "name", from: json)
+		
+		duration = xcOptional(element: "duration", from: json) ?? 0.0
+		subtestGroups = xcArray(element: "subtests", from: json)
+			.ofType(ActionTestSummaryGroup.self)
+		subtests = xcArray(element: "subtests", from: json)
+			.ofType(ActionTestMetadata.self)
+		skipNoticeSummary = xcOptional(element: "skipNoticeSummary", from: json)
+		summary = xcOptional(element: "summary", from: json)
+		documentation = xcArray(element: "documentation", from: json)
+			.ofType(TestDocumentation.self)
+		trackedIssues = xcArray(element: "trackedIssues", from: json)
+			.ofType(IssueTrackingMetadata.self)
+		tags = xcArray(element: "tags", from: json)
+			.ofType(TestTag.self)
+	}
 }

--- a/Sources/XCResultKit/Schema/ActionTestableSummary.swift
+++ b/Sources/XCResultKit/Schema/ActionTestableSummary.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by David House on 7/3/19.
 //
@@ -20,27 +20,37 @@
 import Foundation
 
 public struct ActionTestableSummary: XCResultObject {
-    public let name: String?
-    public let identifierURL: String?
-    public let projectRelativePath: String?
-    public let targetName: String?
-    public let testKind: String?
-    public let tests: [ActionTestSummaryGroup]
-    public let diagnosticsDirectoryName: String?
-    public let failureSummaries: [ActionTestFailureSummary]
-    public let testLanguage: String?
-    public let testRegion: String?
-    
-    public init?(_ json: [String: AnyObject]) {
-        name = xcOptional(element: "name", from: json)
-        identifierURL = xcOptional(element: "identifierURL", from: json)
-        projectRelativePath = xcOptional(element: "projectRelativePath", from: json)
-        targetName = xcOptional(element: "targetName", from: json)
-        testKind = xcOptional(element: "testKind", from: json)
-        tests = xcArray(element: "tests", from: json).ofType(ActionTestSummaryGroup.self)
-        diagnosticsDirectoryName = xcOptional(element: "diagnosticsDirectoryName", from: json)
-        failureSummaries = xcArray(element: "failureSummaries", from: json).ofType(ActionTestFailureSummary.self)
-        testLanguage = xcOptional(element: "testLanguage", from: json)
-        testRegion = xcOptional(element: "testRegion", from: json)
-    }
+	public let name: String?
+	public let identifierURL: String?
+	public let projectRelativePath: String?
+	public let targetName: String?
+	public let testKind: String?
+	public let tests: [ActionTestSummaryGroup]
+	//Note that this is a "synthetic" property, the actual global tests are coming interspersed in the tests array (yuck, mixing types in the same array)
+	public let globalTests: [ActionTestMetadata]
+	public let diagnosticsDirectoryName: String?
+	public let failureSummaries: [ActionTestFailureSummary]
+	public let testLanguage: String?
+	public let testRegion: String?
+	
+	public init?(_ json: [String: AnyObject]) {
+		name = xcOptional(element: "name", from: json)
+		identifierURL = xcOptional(element: "identifierURL", from: json)
+		projectRelativePath = xcOptional(element: "projectRelativePath", from: json)
+		targetName = xcOptional(element: "targetName", from: json)
+		testKind = xcOptional(element: "testKind", from: json)
+		
+		//This is messed up, but in the case where we have global function Swift Tests (new in Xcode 16), there appears to a missing level in the data we are getting
+		//ActionTestableSummary is supposed to have an array of ActionTestSummaryGroup, but it appears they are instead ActionTestMetadata, and that these will be mixed with ActionTestSummaryGroups.  Ugh.
+		//The result of this that if we do nothing the global tests just won't parse and are dropped.
+		//Consider filing this as a bug with Apple...
+		let testsJson = xcArray(element: "tests", from: json)
+		tests = testsJson.ofType(ActionTestSummaryGroup.self)
+		globalTests = testsJson.ofType(ActionTestMetadata.self)
+		
+		diagnosticsDirectoryName = xcOptional(element: "diagnosticsDirectoryName", from: json)
+		failureSummaries = xcArray(element: "failureSummaries", from: json).ofType(ActionTestFailureSummary.self)
+		testLanguage = xcOptional(element: "testLanguage", from: json)
+		testRegion = xcOptional(element: "testRegion", from: json)
+	}
 }

--- a/Sources/XCResultKit/Schema/IssueTrackingMetadata.swift
+++ b/Sources/XCResultKit/Schema/IssueTrackingMetadata.swift
@@ -1,0 +1,35 @@
+//
+//  IssueTrackingMetadata.swift
+//  
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+// - IssueTrackingMetadata
+//   * Kind: object
+//   * Properties:
+//	 + identifier: String
+//	 + url: URL?
+//	 + comment: String?
+//	 + summary: String
+public struct IssueTrackingMetadata: XCResultObject {
+	public let identifier: String
+	public let url: String?
+	public let comment: String?
+	public let summary: String
+	
+	public init?(_ json: [String: AnyObject]) {
+		
+		do {
+			identifier = try xcRequired(element: "identifier", from: json)
+			url = xcOptional(element: "url", from: json)
+			comment = xcOptional(element: "comment", from: json)
+			summary = try xcRequired(element: "summary", from: json)
+		} catch {
+			logError("Error parsing IssueTrackingMetadata: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/Sources/XCResultKit/Schema/TestArgument.swift
+++ b/Sources/XCResultKit/Schema/TestArgument.swift
@@ -19,7 +19,7 @@ import Foundation
 public struct TestArgument: XCResultObject {
 	public let parameter: TestParameter?
 	public let identifier: String?
-	public let description: String
+	public let description: String?
 	public let debugDescription: String?
 	public let typeName: String?
 	public let value: TestValue
@@ -28,7 +28,8 @@ public struct TestArgument: XCResultObject {
 		do {
 			parameter = xcOptional(element: "parameter", from: json)
 			identifier = xcOptional(element: "identifier", from: json)
-			description = try xcRequired(element: "description", from: json)
+			//Note schema says that description is required, but I found it to be missing when testing
+			description = xcOptional(element: "description", from: json)
 			debugDescription = xcOptional(element: "debugDescription", from: json)
 			typeName = xcOptional(element: "typeName", from: json)
 			value = try xcRequired(element: "value", from: json)

--- a/Sources/XCResultKit/Schema/TestArgument.swift
+++ b/Sources/XCResultKit/Schema/TestArgument.swift
@@ -1,0 +1,41 @@
+//
+//  TestArgument.swift
+//
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+//- TestArgument
+//  * Kind: object
+//  * Properties:
+//	+ parameter: TestParameter?
+//	+ identifier: String?
+//	+ description: String
+//	+ debugDescription: String?
+//	+ typeName: String?
+//	+ value: TestValue
+public class TestArgument: XCResultObject {
+	public let parameter: TestParameter?
+	public let identifier: String?
+	public let description: String
+	public let debugDescription: String?
+	public let typeName: String?
+	public let value: TestValue
+
+	required public init?(_ json: [String: AnyObject]) {
+		do {
+			parameter = xcOptional(element: "parameter", from: json)
+			identifier = xcOptional(element: "identifier", from: json)
+			description = try xcRequired(element: "description", from: json)
+			debugDescription = xcOptional(element: "debugDescription", from: json)
+			typeName = xcOptional(element: "typeName", from: json)
+			value = try xcRequired(element: "value", from: json)
+		} catch {
+			logError("Error parsing TestArgument: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}
+

--- a/Sources/XCResultKit/Schema/TestArgument.swift
+++ b/Sources/XCResultKit/Schema/TestArgument.swift
@@ -16,7 +16,7 @@ import Foundation
 //	+ debugDescription: String?
 //	+ typeName: String?
 //	+ value: TestValue
-public class TestArgument: XCResultObject {
+public struct TestArgument: XCResultObject {
 	public let parameter: TestParameter?
 	public let identifier: String?
 	public let description: String
@@ -24,7 +24,7 @@ public class TestArgument: XCResultObject {
 	public let typeName: String?
 	public let value: TestValue
 
-	required public init?(_ json: [String: AnyObject]) {
+	public init?(_ json: [String: AnyObject]) {
 		do {
 			parameter = xcOptional(element: "parameter", from: json)
 			identifier = xcOptional(element: "identifier", from: json)

--- a/Sources/XCResultKit/Schema/TestDocumentation.swift
+++ b/Sources/XCResultKit/Schema/TestDocumentation.swift
@@ -1,0 +1,29 @@
+//
+//  TestDocumentation.swift
+//  
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+//- TestDocumentation
+//  * Kind: object
+//  * Properties:
+//	+ content: String
+//	+ format: String
+public struct TestDocumentation: XCResultObject {
+	public let content: String
+	public let format: String
+	
+	public init?(_ json: [String: AnyObject]) {
+		
+		do {
+			content = try xcRequired(element: "content", from: json)
+			format = try xcRequired(element: "format", from: json)
+		} catch {
+			logError("Error parsing TestDocumentation: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/Sources/XCResultKit/Schema/TestExpression.swift
+++ b/Sources/XCResultKit/Schema/TestExpression.swift
@@ -1,0 +1,35 @@
+//
+//  TestExpression.swift
+//  
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+// Note that because this type uses nested recursion, it cannot be a struct, it must be a class
+//- TestExpression
+//  * Kind: object
+//  * Properties:
+//	+ sourceCode: String
+//	+ value: TestValue?
+//	+ subexpressions: [TestExpression]
+public class TestExpression: XCResultObject {
+	
+	public let sourceCode: String
+	public let value: TestValue?
+	public let subexpressions: [TestExpression]
+	
+	required public init?(_ json: [String: AnyObject]) {
+		
+		do {
+			sourceCode = try xcRequired(element: "sourceCode", from: json)
+			value = xcOptional(element: "value", from: json)
+			subexpressions = xcArray(element: "subexpressions", from: json)
+				.ofType(TestExpression.self)
+		} catch {
+			logError("Error parsing TestExpression: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/Sources/XCResultKit/Schema/TestParameter.swift
+++ b/Sources/XCResultKit/Schema/TestParameter.swift
@@ -1,0 +1,36 @@
+//
+//  TestParameter.swift
+//
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+//- TestParameter
+//  * Kind: object
+//  * Properties:
+//	+ label: String
+//	+ name: String?
+//	+ typeName: String?
+//	+ fullyQualifiedTypeName: String?
+public struct TestParameter: XCResultObject {
+	public let label: String
+	public let name: String?
+	
+	public let typeName: String?
+	public let fullyQualifiedTypeName: String?
+
+
+	public init?(_ json: [String: AnyObject]) {
+		do {
+			label = try xcRequired(element: "label", from: json)
+			name = xcOptional(element: "name", from: json)
+			typeName = xcOptional(element: "typeName", from: json)
+			fullyQualifiedTypeName = xcOptional(element: "fullyQualifiedTypeName", from: json)
+		} catch {
+			logError("Error parsing TestParameter: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/Sources/XCResultKit/Schema/TestTag.swift
+++ b/Sources/XCResultKit/Schema/TestTag.swift
@@ -1,0 +1,31 @@
+//
+//  TestTag.swift
+//
+//
+//  Created by Blechman, Ben on 6/20/24.
+//
+//- TestTag
+//  * Kind: object
+//  * Properties:
+//	+ identifier: String
+//	+ name: String
+//	+ anchors: [String]
+
+import Foundation
+
+public struct TestTag: XCResultObject {
+	public let identifier: String
+	public let name: String
+	public let anchors: String
+	
+	public init?(_ json: [String: AnyObject]) {
+		do {
+			identifier = try xcRequired(element: "identifier", from: json)
+			name = try xcRequired(element: "name", from: json)
+			anchors = try xcRequired(element: "anchors", from: json)
+		} catch {
+			logError("Error parsing TestTag: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/Sources/XCResultKit/Schema/TestTag.swift
+++ b/Sources/XCResultKit/Schema/TestTag.swift
@@ -14,15 +14,15 @@
 import Foundation
 
 public struct TestTag: XCResultObject {
-	public let identifier: String
+	public let identifier: String?
 	public let name: String
-	public let anchors: String
+	public let anchors: String?
 	
 	public init?(_ json: [String: AnyObject]) {
 		do {
-			identifier = try xcRequired(element: "identifier", from: json)
+			identifier = xcOptional(element: "identifier", from: json)
 			name = try xcRequired(element: "name", from: json)
-			anchors = try xcRequired(element: "anchors", from: json)
+			anchors = xcOptional(element: "anchors", from: json)
 		} catch {
 			logError("Error parsing TestTag: \(error.localizedDescription)")
 			return nil

--- a/Sources/XCResultKit/Schema/TestValue.swift
+++ b/Sources/XCResultKit/Schema/TestValue.swift
@@ -23,7 +23,8 @@ public class TestValue: XCResultObject {
 	public let typeName: String?
 	public let fullyQualifiedTypeName: String?
 	public let label: String?
-	public let isCollection: Bool
+	//Required in schema, missing in practice
+	public let isCollection: Bool?
 	public let children: TestValue?
 	
 	required public init?(_ json: [String: AnyObject]) {
@@ -34,7 +35,7 @@ public class TestValue: XCResultObject {
 			typeName = xcOptional(element: "typeName", from: json)
 			fullyQualifiedTypeName = xcOptional(element: "fullyQualifiedTypeName", from: json)
 			label = xcOptional(element: "label", from: json)
-			isCollection = try xcRequired(element: "isCollection", from: json)
+			isCollection = xcOptional(element: "isCollection", from: json)
 			children = xcOptional(element: "children", from: json)
 		} catch {
 			logError("Error parsing TestValue: \(error.localizedDescription)")

--- a/Sources/XCResultKit/Schema/TestValue.swift
+++ b/Sources/XCResultKit/Schema/TestValue.swift
@@ -1,0 +1,44 @@
+//
+//  TestValue.swift
+//
+//
+//  Created by Blechman, Ben on 6/24/24.
+//
+
+import Foundation
+
+//- TestValue
+//  * Kind: object
+//  * Properties:
+//	+ description: String
+//	+ debugDescription: String?
+//	+ typeName: String?
+//	+ fullyQualifiedTypeName: String?
+//	+ label: String?
+//	+ isCollection: Bool
+//	+ children: TestValue?
+public class TestValue: XCResultObject {
+	public let description: String
+	public let debugDescription: String?
+	public let typeName: String?
+	public let fullyQualifiedTypeName: String?
+	public let label: String?
+	public let isCollection: Bool
+	public let children: TestValue?
+	
+	required public init?(_ json: [String: AnyObject]) {
+		
+		do {
+			description = try xcRequired(element: "description", from: json)
+			debugDescription = xcOptional(element: "debugDescription", from: json)
+			typeName = xcOptional(element: "typeName", from: json)
+			fullyQualifiedTypeName = xcOptional(element: "fullyQualifiedTypeName", from: json)
+			label = xcOptional(element: "label", from: json)
+			isCollection = try xcRequired(element: "isCollection", from: json)
+			children = xcOptional(element: "children", from: json)
+		} catch {
+			logError("Error parsing TestValue: \(error.localizedDescription)")
+			return nil
+		}
+	}
+}

--- a/XCResultFormat.md
+++ b/XCResultFormat.md
@@ -1,6 +1,6 @@
 Name: Xcode Result Types
-Version: 3.44
-Signature: G3FAemVu1AQ=
+Version: 3.53
+Signature: HAB7BB+BxgA=
 Types:
   - ActionAbstractTestSummary
     * Kind: object
@@ -124,6 +124,7 @@ Types:
       + sourceCodeContext: SourceCodeContext?
       + timestamp: Date?
       + isTopLevelFailure: Bool
+      + expression: TestExpression?
   - ActionTestIssueSummary
     * Kind: object
     * Properties:
@@ -195,14 +196,24 @@ Types:
       + skipNoticeSummary: ActionTestNoticeSummary?
       + activitySummaries: [ActionTestActivitySummary]
       + repetitionPolicySummary: ActionTestRepetitionPolicySummary?
+      + arguments: [TestArgument]
       + configuration: ActionTestConfiguration?
       + warningSummaries: [ActionTestIssueSummary]
+      + summary: String?
+      + documentation: [TestDocumentation]
+      + trackedIssues: [IssueTrackingMetadata]
+      + tags: [TestTag]
   - ActionTestSummaryGroup
     * Supertype: ActionTestSummaryIdentifiableObject
     * Kind: object
     * Properties:
       + duration: Double
       + subtests: [ActionTestSummaryIdentifiableObject]
+      + skipNoticeSummary: ActionTestNoticeSummary?
+      + summary: String?
+      + documentation: [TestDocumentation]
+      + trackedIssues: [IssueTrackingMetadata]
+      + tags: [TestTag]
   - ActionTestSummaryIdentifiableObject
     * Supertype: ActionAbstractTestSummary
     * Kind: object
@@ -308,6 +319,14 @@ Types:
       + location: DocumentLocation?
       + subsections: [ActivityLogSection]
       + messages: [ActivityLogMessage]
+      + attachments: [ActivityLogSectionAttachment]
+  - ActivityLogSectionAttachment
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + majorVersion: UInt8
+      + minorVersion: UInt8
+      + data: Data
   - ActivityLogTargetBuildSection
     * Supertype: ActivityLogMajorSection
     * Kind: object
@@ -372,6 +391,8 @@ Types:
     * Properties:
       + title: String
       + items: [ConsoleLogItem]
+  - Data
+    * Kind: value
   - Date
     * Kind: value
   - DocumentLocation
@@ -405,6 +426,13 @@ Types:
       + message: String
       + producingTarget: String?
       + documentLocationInCreatingWorkspace: DocumentLocation?
+  - IssueTrackingMetadata
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + url: URL?
+      + comment: String?
+      + summary: String
   - ObjectID
     * Kind: object
     * Properties:
@@ -464,12 +492,32 @@ Types:
       + location: SourceCodeLocation?
   - String
     * Kind: value
+  - TestArgument
+    * Kind: object
+    * Properties:
+      + parameter: TestParameter?
+      + identifier: String?
+      + description: String
+      + debugDescription: String?
+      + typeName: String?
+      + value: TestValue
   - TestAssociatedError
     * Kind: object
     * Properties:
       + domain: String?
       + code: Int?
       + userInfo: SortedKeyValueArray?
+  - TestDocumentation
+    * Kind: object
+    * Properties:
+      + content: String
+      + format: String
+  - TestExpression
+    * Kind: object
+    * Properties:
+      + sourceCode: String
+      + value: TestValue?
+      + subexpressions: [TestExpression]
   - TestFailureIssueSummary
     * Supertype: IssueSummary
     * Kind: object
@@ -480,6 +528,29 @@ Types:
     * Kind: object
     * Properties:
       + testCaseName: String
+  - TestParameter
+    * Kind: object
+    * Properties:
+      + label: String
+      + name: String?
+      + typeName: String?
+      + fullyQualifiedTypeName: String?
+  - TestTag
+    * Kind: object
+    * Properties:
+      + identifier: String
+      + name: String
+      + anchors: [String]
+  - TestValue
+    * Kind: object
+    * Properties:
+      + description: String
+      + debugDescription: String?
+      + typeName: String?
+      + fullyQualifiedTypeName: String?
+      + label: String?
+      + isCollection: Bool
+      + children: TestValue?
   - TypeDefinition
     * Kind: object
     * Properties:
@@ -492,4 +563,6 @@ Types:
   - UInt64
     * Kind: value
   - UInt8
+    * Kind: value
+  - URL
     * Kind: value


### PR DESCRIPTION
Xcode 16.0 introduces a bunch of new features related to Swift Testing.  As this is going to be the default for new test targets once 16.0 is released it seems necessary for us to get out ahead of it, as we produce test data from the .xcresult bundles.

I've updated with new model objects from the new schema additions.