### PR TITLE
feat: run project inside linux

### DIFF
--- a/Sources/XCResultKit/XCResultFile.swift
+++ b/Sources/XCResultKit/XCResultFile.swift
@@ -197,34 +197,32 @@ public class XCResultFile {
     
     @discardableResult
     private func xcrun(_ arguments: [String], output: XCRunOutput = .onlyOnSuccess) -> Data? {
-        autoreleasepool {
-            let task = Process()
-            task.launchPath = "/usr/bin/xcrun"
-            task.arguments = arguments
+        let task = Process()
+        task.launchPath = "/usr/bin/xcrun"
+        task.arguments = arguments
+        
+        var resultData: Data?
+        if output != .never {
+            let pipe = Pipe()
+            task.standardOutput = pipe
+            task.launch()
             
-            var resultData: Data?
-            if output != .never {
-                let pipe = Pipe()
-                task.standardOutput = pipe
-                task.launch()
-                
-                resultData = pipe.fileHandleForReading.readDataToEndOfFile()
-            } else {
-                task.launch()
-            }
-            
-            task.waitUntilExit()
-
-            let taskSucceeded = task.terminationStatus == EXIT_SUCCESS
-            
-            switch output {
-            case .always:
-                return resultData
-            case .onlyOnSuccess:
-                return taskSucceeded ? resultData : nil
-            case .never:
-                return nil
-            }
+            resultData = pipe.fileHandleForReading.readDataToEndOfFile()
+        } else {
+            task.launch()
+        }
+        
+        task.waitUntilExit()
+        
+        let taskSucceeded = task.terminationStatus == EXIT_SUCCESS
+        
+        switch output {
+        case .always:
+            return resultData
+        case .onlyOnSuccess:
+            return taskSucceeded ? resultData : nil
+        case .never:
+            return nil
         }
     }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import XCResultKitTests
-
-var tests = [XCTestCaseEntry]()
-tests += XCResultKitTests.allTests()
-XCTMain(tests)

--- a/Tests/XCResultKitTests/ActionTestPlanRunSummaryTests.swift
+++ b/Tests/XCResultKitTests/ActionTestPlanRunSummaryTests.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  
-//
-//  Created by David House on 7/3/19.
-//
-
-import Foundation

--- a/Tests/XCResultKitTests/XCResultFileTests.swift
+++ b/Tests/XCResultKitTests/XCResultFileTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+#if os(macOS)
 import XCTest
 @testable import XCResultKit
 
@@ -12,7 +12,7 @@ final class XCResultFileTests: XCTestCase {
     lazy var temporaryOutputDirectoryURL:URL  = {
         // Setup a temp test folder that can be used as a sandbox
         let tempDirectoryURL = FileManager.default.temporaryDirectory
-        let temporaryOutputDirectoryName = ProcessInfo().globallyUniqueString
+        let temporaryOutputDirectoryName = UUID().uuidString
         let temporaryOutputDirectoryURL =
         tempDirectoryURL.appendingPathComponent(temporaryOutputDirectoryName)
         tempDirectoryURL.createDirectoryIfNecessary(createIntermediates: false)
@@ -131,3 +131,4 @@ public extension Foundation.URL {
         }
     }
 }
+#endif

--- a/Tests/XCResultKitTests/XCTestManifests.swift
+++ b/Tests/XCResultKitTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(XCResultKitTests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
Actually the library can't build on linux;

The package can be run only inside macOS environment, but the package can be used inside an executable cli can work in both linux and macOS, so it's why we need to be able to just build inside linux and of course macOS.

the big issue is `autoreleasepool`, why it's needed inside the project ? I trie this branch from many months and any issue on macOS and linux when I removed the `autoreleasepool` function